### PR TITLE
agents(workflow): enforce PR-based workflow for all changes

### DIFF
--- a/.claude/instructions/git-github.md
+++ b/.claude/instructions/git-github.md
@@ -1,35 +1,55 @@
 # Git & GitHub Guidelines
 
+## Golden Rule
+
+**NEVER push directly to `main`.** All changes must go through a Pull Request with approval.
+
 ## Branch Strategy
 
-| Branch | Purpose | Deploys To |
-|--------|---------|------------|
-| `main` | Development, integration | - |
-| `release/*` | Production releases (e.g., `release/1.0`) | Firebase + Cloud Run |
-| `feature/*` | New features | - |
-| `fix/*` | Bug fixes | - |
+| Branch | Purpose | Deploys To | Direct Push |
+|--------|---------|------------|-------------|
+| `main` | Development, integration | - | **BLOCKED** |
+| `release/*` | Production releases (e.g., `release/1.0`) | Firebase + Cloud Run | No |
+| `feature/*` | New features | - | Yes |
+| `fix/*` | Bug fixes | - | Yes |
+| `agents/*` | AI agent config changes | - | Yes |
 
 ## Workflow
 
 ```bash
-# Start new feature
+# 1. Start from main
 git checkout main
-git pull
+git pull origin main
+
+# 2. Create branch (NEVER work on main)
 git checkout -b feature/my-feature
 
-# Work on feature...
+# 3. Make changes and commit
 git add .
 git commit -m "feature: add new feature"
 
-# Push and create PR
+# 4. Push branch (NOT main!)
 git push -u origin feature/my-feature
-# Open PR to main
 
-# After PR merge, deploy
-git checkout release/1.0  # or create new release branch
-git merge main
-git push
+# 5. Open PR on GitHub with:
+#    - Title: type(scope): description
+#    - Summary of all changes
+#    - Request review
+#    - Wait for APPROVAL before merge
+
+# 6. After PR is approved and merged
+git checkout main
+git pull origin main
+git branch -d feature/my-feature
 ```
+
+## Pull Request Requirements
+
+Every PR must have:
+1. **Title** - Conventional commit format
+2. **Summary** - Description of all changes made
+3. **Testing** - How changes were verified
+4. **Approval** - Manual review before merge
 
 ## Commit Convention
 

--- a/.github/skills/git-github/SKILL.md
+++ b/.github/skills/git-github/SKILL.md
@@ -5,14 +5,19 @@ description: "Git workflow and GitHub conventions for this project. USE WHEN com
 
 # Git & GitHub Workflow
 
+## Golden Rule
+
+**NEVER push directly to `main`.** All changes must go through a Pull Request.
+
 ## Branch Strategy
 
-| Branch | Purpose | Auto-deploys |
-|--------|---------|--------------|
-| `main` | Development integration | No |
-| `release/*` | Production releases (e.g., `release/1.0`, `release/2.0`) | Yes (Firebase + Cloud Run) |
-| `feature/*` | New features | No |
-| `fix/*` | Bug fixes | No |
+| Branch | Purpose | Auto-deploys | Direct Push |
+|--------|---------|--------------|-------------|
+| `main` | Development integration | No | **BLOCKED** |
+| `release/*` | Production releases (e.g., `release/1.0`, `release/2.0`) | Yes (Firebase + Cloud Run) | No |
+| `feature/*` | New features | No | Yes |
+| `fix/*` | Bug fixes | No | Yes |
+| `agents/*` | AI agent config changes | No | Yes |
 
 ## Feature Development Flow
 
@@ -21,23 +26,37 @@ description: "Git workflow and GitHub conventions for this project. USE WHEN com
 git checkout main
 git pull origin main
 
-# 2. Create feature branch
+# 2. Create feature branch (NEVER work on main)
 git checkout -b feature/room-creation
 
 # 3. Make changes and commit
 git add .
-git commit -m "feat(client): add room creation UI"
+git commit -m "feature(client): add room creation UI"
 
-# 4. Push and create PR
+# 4. Push branch (NOT main!)
 git push -u origin feature/room-creation
-# Then open PR to main on GitHub
 
-# 5. After PR merge, deploy to production
-git checkout release/1.0  # or create new release branch
-git pull origin release/1.0
-git merge main
-git push origin release/1.0
+# 5. Open PR on GitHub
+#    - Title: feature(client): add room creation UI
+#    - Description: Summary of all changes
+#    - Request review
+#    - Wait for approval
+
+# 6. After PR is APPROVED and MERGED (by reviewer)
+#    Delete local branch
+git checkout main
+git pull origin main
+git branch -d feature/room-creation
 ```
+
+## Pull Request Requirements
+
+**Every PR must include:**
+
+1. **Title** - Conventional commit format: `type(scope): description`
+2. **Summary** - What changes were made and why
+3. **Testing** - How the changes were verified
+4. **Approval** - At least one reviewer must approve before merge
 
 ## Commit Convention (Conventional Commits)
 


### PR DESCRIPTION
## Summary

Updates the Git workflow documentation to enforce that all changes go through Pull Requests - never pushing directly to `main`.

## Changes

### Added
- **Golden Rule** section: "NEVER push directly to `main`"
- **`agents/*` branch type** for AI agent configuration changes
- **Pull Request Requirements** section with mandatory checklist:
  - Title in conventional commit format
  - Summary of all changes
  - Testing verification
  - Manual approval before merge
- **Direct Push column** in branch strategy table

### Updated
- Workflow steps now explicitly show PR approval flow
- Branch cleanup step added after PR merge
- Comments clarify "NOT main!" at critical steps

## Files Changed
- `.github/skills/git-github/SKILL.md`
- `.claude/instructions/git-github.md`

## Testing
- Documentation review only, no code changes