### PR TITLE
feature(client): move benches to top/bottom with compact layout

### DIFF
--- a/apps/client/src/app/components/bench/bench.component.html
+++ b/apps/client/src/app/components/bench/bench.component.html
@@ -5,7 +5,7 @@
   [class.bench--player-2]="playerId() === 2"
 >
   <div class="bench-header">
-    <span class="bench-title">Player {{ playerId() }} Bench</span>
+    <span class="bench-title">P{{ playerId() }}</span>
     @if (isCurrentPlayer()) {
       <span class="bench-indicator">Your Turn</span>
     }
@@ -17,6 +17,7 @@
         class="bench-slot"
         [class.bench-slot--selected]="selectedPokemonId() === p.id"
         [class.bench-slot--selectable]="isCurrentPlayer()"
+        [title]="getSpecies(p.speciesId)?.name ?? ''"
         (click)="onPokemonClick(p)"
       >
         <img 
@@ -24,13 +25,10 @@
           [src]="getSpecies(p.speciesId)?.imageUrl" 
           [alt]="getSpecies(p.speciesId)?.name"
         />
-        <div class="bench-pokemon-info">
-          <span class="bench-pokemon-name">{{ getSpecies(p.speciesId)?.name }}</span>
-          <span class="bench-pokemon-movement">Move: {{ getSpecies(p.speciesId)?.movement }}</span>
-        </div>
+        <span class="bench-move-badge">{{ getSpecies(p.speciesId)?.movement }}</span>
       </div>
     } @empty {
-      <div class="bench-empty">No Pokemon on bench</div>
+      <div class="bench-empty">No Pokemon</div>
     }
   </div>
 </div>

--- a/apps/client/src/app/components/bench/bench.component.scss
+++ b/apps/client/src/app/components/bench/bench.component.scss
@@ -1,9 +1,16 @@
+:host {
+  display: block;
+}
+
 .bench {
   background-color: #f5f5f5;
   border: 2px solid #ccc;
   border-radius: 8px;
-  padding: clamp(8px, 1vw, 12px);
+  padding: 6px 8px;
   min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 
   &--active {
     border-color: #2196f3;
@@ -21,26 +28,27 @@
 
 .bench-header {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: center;
-  margin-bottom: clamp(8px, 1vw, 12px);
-  padding-bottom: clamp(4px, 0.5vw, 8px);
-  border-bottom: 1px solid #ddd;
+  gap: 2px;
+  flex-shrink: 0;
 }
 
 .bench-title {
-  font-weight: 600;
-  font-size: clamp(11px, 1.2vw, 14px);
+  font-weight: 700;
+  font-size: 11px;
   color: #333;
+  line-height: 1;
 }
 
 .bench-indicator {
   background-color: #4caf50;
   color: #fff;
-  padding: 2px clamp(4px, 0.5vw, 8px);
-  border-radius: 12px;
-  font-size: clamp(9px, 1vw, 11px);
+  padding: 1px 5px;
+  border-radius: 8px;
+  font-size: 9px;
   font-weight: 600;
+  white-space: nowrap;
   animation: pulse 1.5s infinite;
 }
 
@@ -55,18 +63,21 @@
 
 .bench-pokemon {
   display: flex;
-  flex-direction: column;
-  gap: clamp(4px, 0.5vw, 8px);
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
 }
 
 .bench-slot {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: clamp(6px, 0.8vw, 10px);
-  padding: clamp(4px, 0.5vw, 8px);
+  justify-content: center;
+  padding: 3px;
   background-color: #fff;
   border: 2px solid #e0e0e0;
-  border-radius: 6px;
+  border-radius: 50%;
   transition: all 0.15s ease;
 
   &--selectable {
@@ -75,6 +86,7 @@
     &:hover {
       border-color: #2196f3;
       background-color: #e3f2fd;
+      transform: scale(1.1);
     }
   }
 
@@ -86,39 +98,35 @@
 }
 
 .bench-pokemon-image {
-  width: clamp(32px, 4vw, 48px);
-  height: clamp(32px, 4vw, 48px);
+  width: 36px;
+  height: 36px;
   object-fit: contain;
-  background-color: #f9f9f9;
   border-radius: 50%;
-  padding: clamp(2px, 0.3vw, 4px);
+  display: block;
 }
 
-.bench-pokemon-info {
+.bench-move-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background-color: #1976d2;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
   display: flex;
-  flex-direction: column;
-  gap: 2px;
-  overflow: hidden;
-}
-
-.bench-pokemon-name {
-  font-weight: 600;
-  font-size: clamp(10px, 1.1vw, 13px);
-  color: #333;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.bench-pokemon-movement {
-  font-size: clamp(9px, 1vw, 11px);
-  color: #666;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
 }
 
 .bench-empty {
   text-align: center;
-  padding: clamp(12px, 1.5vw, 20px);
+  padding: 4px 8px;
   color: #999;
   font-style: italic;
-  font-size: clamp(10px, 1vw, 12px);
+  font-size: 11px;
 }

--- a/apps/client/src/app/containers/game-board/game-board.component.html
+++ b/apps/client/src/app/containers/game-board/game-board.component.html
@@ -33,8 +33,8 @@
     </div>
   }
 
-  <!-- Player 1 Bench (Left side) -->
-  <aside class="bench-area bench-area--left">
+  <!-- Player 1 Bench (Top) -->
+  <aside class="bench-area bench-area--top">
     <app-bench
       [pokemon]="player1Bench()"
       [playerId]="1"
@@ -132,8 +132,8 @@
     }
   </main>
 
-  <!-- Player 2 Bench (Right side) -->
-  <aside class="bench-area bench-area--right">
+  <!-- Player 2 Bench (Bottom) -->
+  <aside class="bench-area bench-area--bottom">
     <app-bench
       [pokemon]="player2Bench()"
       [playerId]="2"

--- a/apps/client/src/app/containers/game-board/game-board.component.scss
+++ b/apps/client/src/app/containers/game-board/game-board.component.scss
@@ -1,24 +1,23 @@
 .game-layout {
   display: flex;
-  gap: clamp(8px, 2vw, 20px);
+  flex-direction: column;
+  gap: clamp(4px, 1vw, 12px);
   height: 100%;
-  padding: clamp(8px, 2vw, 20px);
+  padding: clamp(4px, 1vw, 12px);
   box-sizing: border-box;
   background-color: #e8e8e8;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .bench-area {
   flex-shrink: 0;
-  width: clamp(120px, 15vw, 220px);
-  display: flex;
-  flex-direction: column;
+  width: 100%;
 
-  &--left {
+  &--top {
     order: 1;
   }
 
-  &--right {
+  &--bottom {
     order: 3;
   }
 }
@@ -29,21 +28,24 @@
   flex-direction: column;
   order: 2;
   min-width: 0;
+  min-height: 0;
 }
 
 .game-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 16px;
+  padding: 8px 12px;
   background-color: #fff;
   border-radius: 8px;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  flex-wrap: wrap;
+  gap: 6px;
 
   h2 {
     margin: 0;
-    font-size: 20px;
+    font-size: clamp(14px, 2.5vw, 20px);
     color: #333;
   }
 }


### PR DESCRIPTION
## Summary
Redesign the game layout for better mobile (iPhone 14) experience by moving benches from left/right sides to top/bottom, and making bench slots compact.

## Changes
- **Game layout** — switched from horizontal flex to vertical (`flex-direction: column`), benches are now full-width strips at top and bottom
- **Bench component** — each Pokemon slot is now a compact circular avatar (36px) with a blue movement-count badge at the top-right corner
- **Pokemon name** — displayed via native `title` tooltip on hover instead of inline text
- **No media queries** — all sizing is fixed/responsive without device-specific breakpoints
- **Header** — now wraps on smaller screens with `flex-wrap`

## Files Changed
- `bench.component.html` — compact template with image + badge + tooltip
- `bench.component.scss` — horizontal row layout, circular slots, badge styling
- `game-board.component.html` — bench areas changed from left/right to top/bottom
- `game-board.component.scss` — column layout, full-width bench areas

## Testing
- [x] Build passes (`nx build client`)
- [x] Manual testing on iPhone 14 viewport
- [x] Preview deployment link below