### PR TITLE
feature(client): integrate bench into canvas with bridge connectors

### DIFF
--- a/apps/client/src/app/containers/game-board/game-board.component.html
+++ b/apps/client/src/app/containers/game-board/game-board.component.html
@@ -66,15 +66,16 @@
       <!-- Bench areas and connectors -->
       @if (benchAreas(); as ba) {
         <svg class="bench-overlay">
-          <!-- P1 bench area (bottom) -->
-          <rect
-            class="bench-area bench-area--player-1"
-            [attr.x]="ba.p1.x + '%'"
-            [attr.y]="ba.p1.y + '%'"
-            [attr.width]="ba.p1.w + '%'"
-            [attr.height]="ba.p1.h + '%'"
-            rx="8" ry="8"
-          />
+          <defs>
+            <!-- Arrowheads pointing toward the board entry spot (P1 = up, P2 = down) -->
+            <marker id="bridge-arrow-p1" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+              <polygon points="0 0, 8 3, 0 6" fill="#42a5f5" opacity="0.9"/>
+            </marker>
+            <marker id="bridge-arrow-p2" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+              <polygon points="0 0, 8 3, 0 6" fill="#ef5350" opacity="0.9"/>
+            </marker>
+          </defs>
+
           <!-- P2 bench area (top) -->
           <rect
             class="bench-area bench-area--player-2"
@@ -84,20 +85,32 @@
             [attr.height]="ba.p2.h + '%'"
             rx="8" ry="8"
           />
-          <!-- Connectors from P1 bench to entry points -->
+          <!-- P1 bench area (bottom) -->
+          <rect
+            class="bench-area bench-area--player-1"
+            [attr.x]="ba.p1.x + '%'"
+            [attr.y]="ba.p1.y + '%'"
+            [attr.width]="ba.p1.w + '%'"
+            [attr.height]="ba.p1.h + '%'"
+            rx="8" ry="8"
+          />
+
+          <!-- Bridges from P1 bench edges to entry spots -->
           @for (c of ba.p1Connectors; track $index) {
             <line
               class="bench-connector bench-connector--player-1"
               [attr.x1]="c.x1 + '%'" [attr.y1]="c.y1 + '%'"
               [attr.x2]="c.x2 + '%'" [attr.y2]="c.y2 + '%'"
+              marker-end="url(#bridge-arrow-p1)"
             />
           }
-          <!-- Connectors from P2 bench to entry points -->
+          <!-- Bridges from P2 bench edges to entry spots -->
           @for (c of ba.p2Connectors; track $index) {
             <line
               class="bench-connector bench-connector--player-2"
               [attr.x1]="c.x1 + '%'" [attr.y1]="c.y1 + '%'"
               [attr.x2]="c.x2 + '%'" [attr.y2]="c.y2 + '%'"
+              marker-end="url(#bridge-arrow-p2)"
             />
           }
         </svg>

--- a/apps/client/src/app/containers/game-board/game-board.component.scss
+++ b/apps/client/src/app/containers/game-board/game-board.component.scss
@@ -85,23 +85,24 @@
 }
 
 .bench-area {
-  fill: none;
   stroke-width: 1.5;
   stroke-dasharray: 6 3;
 
   &--player-1 {
+    fill: rgba(66, 165, 245, 0.06);
     stroke: #42a5f5;
   }
 
   &--player-2 {
+    fill: rgba(239, 83, 80, 0.06);
     stroke: #ef5350;
   }
 }
 
 .bench-connector {
-  stroke-width: 1.5;
-  stroke-dasharray: 4 3;
-  opacity: 0.5;
+  stroke-width: 2.5;
+  stroke-dasharray: 5 3;
+  opacity: 0.85;
 
   &--player-1 {
     stroke: #42a5f5;

--- a/apps/client/src/app/containers/game-board/game-board.component.ts
+++ b/apps/client/src/app/containers/game-board/game-board.component.ts
@@ -13,8 +13,8 @@ const BENCH_MARGIN = 60;
 const CANVAS_DESIGN_HEIGHT = BOARD_DESIGN_HEIGHT + BENCH_MARGIN * 2;
 
 const BENCH_SIZE = 6;
-const BENCH_SLOT_SPACING = 80;
-const BENCH_START_X = (BOARD_DESIGN_WIDTH - (BENCH_SIZE - 1) * BENCH_SLOT_SPACING) / 2;
+const BENCH_SLOT_SPACING = 120; // slots span x=200..800, matching the board's left/right entry spots
+const BENCH_START_X = 200; // aligns leftmost slot with left entry spot (x=200)
 
 export type BenchSlot = {
   index: number;
@@ -51,33 +51,42 @@ export class GameBoardComponent implements OnInit {
 
   // Bench area dimensions (percentages for SVG rendering)
   protected readonly benchAreas = computed(() => {
-    const benchWidth = (BENCH_SIZE - 1) * BENCH_SLOT_SPACING + 60; // slots + padding
-    const benchStartX = BENCH_START_X - 30; // left padding
+    const allSpots = this.spots();
+    const p1Entries = allSpots.filter(
+      (s) => s.metadata.type === 'entry' && 'playerId' in s.metadata && s.metadata.playerId === 1,
+    );
+    const p2Entries = allSpots.filter(
+      (s) => s.metadata.type === 'entry' && 'playerId' in s.metadata && s.metadata.playerId === 2,
+    );
+
+    const benchWidth = (BENCH_SIZE - 1) * BENCH_SLOT_SPACING + 60; // slots + 30px padding each side
+    const benchStartX = BENCH_START_X - 30;
     const x = (benchStartX / BOARD_DESIGN_WIDTH) * 100;
     const w = (benchWidth / BOARD_DESIGN_WIDTH) * 100;
     const h = (BENCH_MARGIN / CANVAS_DESIGN_HEIGHT) * 100;
 
-    // P1 entry points at y=450 → percentY = (450+60)/620
-    const p1EntryY = this.boardToPercentY(450);
-    const p2EntryY = this.boardToPercentY(50);
-    // Entry X positions: 200 and 800
-    const entryLeftX = this.toPercentX(200);
-    const entryRightX = this.toPercentX(800);
+    // Bridge connects from the bench area edge to the entry spot on the board
+    const p1BenchTopY = 100 - h;
+    const p2BenchBottomY = h;
 
     return {
       // P1 bench area (bottom)
       p1: { x, y: 100 - h, w, h },
       // P2 bench area (top)
       p2: { x, y: 0, w, h },
-      // Connector lines from bench edges to entry points
-      p1Connectors: [
-        { x1: entryLeftX, y1: 100 - h, x2: entryLeftX, y2: p1EntryY },
-        { x1: entryRightX, y1: 100 - h, x2: entryRightX, y2: p1EntryY },
-      ],
-      p2Connectors: [
-        { x1: entryLeftX, y1: h, x2: entryLeftX, y2: p2EntryY },
-        { x1: entryRightX, y1: h, x2: entryRightX, y2: p2EntryY },
-      ],
+      // One bridge per entry spot, anchored at matching X coordinate
+      p1Connectors: p1Entries.map((entry) => ({
+        x1: this.toPercentX(entry.x),
+        y1: p1BenchTopY,
+        x2: this.toPercentX(entry.x),
+        y2: this.boardToPercentY(entry.y),
+      })),
+      p2Connectors: p2Entries.map((entry) => ({
+        x1: this.toPercentX(entry.x),
+        y1: p2BenchBottomY,
+        x2: this.toPercentX(entry.x),
+        y2: this.boardToPercentY(entry.y),
+      })),
     };
   });
 


### PR DESCRIPTION
## Summary
- Bench slots now span x=200..800, aligning the outer slots with the board's left and right entry spots
- Bridge connectors are derived dynamically from actual entry spot positions (no more hardcoded coordinates)
- SVG arrowhead markers added to each bridge, pointing toward the board entry spot
- Bench area rectangles now have a subtle tinted fill to visually separate them from the board

## Changes
- `BENCH_SLOT_SPACING`: `80` → `120` so 6 slots span exactly from left entry (x=200) to right entry (x=800)
- `BENCH_START_X`: center-calculated `300` → explicit `200`
- `benchAreas` computed signal now reads entry spots from `this.spots()` — bridges adapt automatically to any board layout
- HTML: added `<defs>` with `bridge-arrow-p1` / `bridge-arrow-p2` SVG markers; connector lines use `marker-end`
- SCSS: connectors thicker (`stroke-width: 2.5`), higher opacity (`0.85`); bench areas get a tinted `fill`

## Testing
- [ ] Visual check: bench slots align with left/right board edges
- [ ] Visual check: two bridge lines with arrowheads connect each player's bench to their entry spots
- [ ] Verify both players' benches are handled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)