### PR TITLE
agents(docs): remove stale docs app references from agent instructions

### DIFF
--- a/.claude/instructions/general.md
+++ b/.claude/instructions/general.md
@@ -6,7 +6,6 @@
 |---------|------|-------------|
 | `client` | Angular app | Browser-based game client |
 | `server` | .NET app | SignalR game server (C#) |
-| `docs` | Analog app | Documentation site (SSR) |
 | `board` | Library | Shared game logic and models |
 
 ## Technology Stack
@@ -25,27 +24,6 @@
 | `firebase.json` | Firebase Hosting configuration |
 | `cloudbuild.yaml` | GCP Cloud Build pipeline |
 | `nx.json` | Nx workspace configuration |
-
-## Documentation Requirements
-
-**Every task must be documented.** When completing work, update or create documentation in `apps/docs/src/content/agents/`.
-
-### When to Update vs. Create
-
-| Situation | Action |
-|-----------|--------|
-| Modifying existing system | Update doc in `architecture/` |
-| Changing patterns/conventions | Update doc in `patterns/` |
-| Adding new feature | Create doc in `features/<feature-name>.md` |
-| Making architectural choice | Create doc in `decisions/<decision-name>.md` |
-| Bug fix or minor change | Skip unless architecture-relevant |
-
-### What to Document
-
-- **Architecture** — System design, component interactions
-- **Patterns** — Recurring solutions, conventions
-- **Features** — What it does, how it works, API contracts
-- **Decisions** — Why we chose X over Y, trade-offs
 
 ## Conventions
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Remove `docs` from the workspace structure table in `general.md` — the Analog docs app no longer exists
- Drop the entire **Documentation Requirements** section that directed agents to write into `apps/docs/src/content/agents/` — dead path, causes confusion

## Test plan

- [ ] No code changes — verify the instructions file looks correct

https://claude.ai/code/session_014csw13t6dhrirXxhqBTDQp
EOF
)