### PR TITLE
agents(docs): remove remaining references to removed docs app

### DIFF
--- a/.claude/instructions/git-github.md
+++ b/.claude/instructions/git-github.md
@@ -33,7 +33,7 @@ Format: `<type>(<scope>): <description>`
 | `perf` | Performance improvement |
 | `agents` | AI agent instructions, skills, workflows |
 
-Scopes: `client`, `server`, `board`, `docs`, `deps`, `ci`
+Scopes: `client`, `server`, `board`, `deps`, `ci`
 
 ## PR Requirements
 

--- a/.github/skills/git-github/SKILL.md
+++ b/.github/skills/git-github/SKILL.md
@@ -60,7 +60,7 @@ Commit format: `<type>(<scope>): <description>`
 | `perf` | Performance |
 | `agents` | AI agent instructions/skills |
 
-Scopes: `client`, `server`, `board`, `docs`, `deps`, `ci`
+Scopes: `client`, `server`, `board`, `deps`, `ci`
 
 Examples:
 ```bash

--- a/.github/skills/nx-run-tasks/SKILL.md
+++ b/.github/skills/nx-run-tasks/SKILL.md
@@ -28,7 +28,6 @@ npx nx run <project>:<task>
 # Examples
 npx nx serve client       # Angular dev server on :4200
 npx nx serve server       # .NET server on :5000
-npx nx serve docs         # Docs site on :5173
 npx nx test board         # Unit tests for board library
 npx nx test client        # Unit tests for Angular client
 npx nx e2e client         # Playwright e2e tests
@@ -42,7 +41,7 @@ npx nx deploy server      # Cloud Run
 ```bash
 npx nx run-many -t build test lint
 npx nx run-many -t test -p client board      # specific projects
-npx nx run-many -t lint --exclude docs       # exclude a project
+npx nx run-many -t lint --exclude server     # exclude a project
 ```
 
 ## Run Only Affected Projects

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,10 +24,6 @@ Read these files for detailed guidelines:
 @.claude/instructions/deployment.md
 @.claude/instructions/git-github.md
 
-## Architecture Documentation
-
-For detailed architecture decisions, read from `apps/docs/src/content/agents/`.
-
 ## Skills
 
 Use skills from `.github/skills/` for specific workflows:


### PR DESCRIPTION
## Summary

Follow-up to #27. Removes all remaining references to the deleted `docs` Analog app from agent instructions and skills.

- **`CLAUDE.md`** — drop the "Architecture Documentation" section that pointed agents at `apps/docs/src/content/agents/`
- **`.claude/instructions/git-github.md`** — remove `docs` from the commit scopes list
- **`.github/skills/git-github/SKILL.md`** — same scope list cleanup
- **`.github/skills/nx-run-tasks/SKILL.md`** — remove `npx nx serve docs` example; update `--exclude` example to use `server`

Note: the `docs` **commit type** (`docs: ...`) and `docs/*` **branch prefix** are intentionally kept — those are conventional-commits conventions that apply to any documentation change, not specific to the removed app.

## Test plan

- [ ] No code changes — verify the four instruction files look correct

https://claude.ai/code/session_014csw13t6dhrirXxhqBTDQp