### PR TITLE
style(client): redesign entire client UI/UX with Pokemon-themed design system

### DIFF
--- a/apps/client/src/app/app.html
+++ b/apps/client/src/app/app.html
@@ -1,22 +1,29 @@
-<mat-toolbar color="primary">
-  <mat-icon>sports_esports</mat-icon>
-  <span class="brand-text">Pokemon Duel</span>
+<nav class="game-nav">
+  <div class="nav-brand">
+    <svg class="nav-pokeball" viewBox="0 0 24 24" width="26" height="26" aria-hidden="true">
+      <circle cx="12" cy="12" r="11" fill="white"/>
+      <path d="M1.2 12 A10.8 10.8 0 0 1 22.8 12 Z" fill="#E63946"/>
+      <line x1="1.2" y1="12" x2="22.8" y2="12" stroke="#333" stroke-width="1.5"/>
+      <circle cx="12" cy="12" r="3.2" fill="white" stroke="#333" stroke-width="1.5"/>
+    </svg>
+    <span class="nav-title">POKEMON DUEL</span>
+  </div>
 
-  <span class="spacer"></span>
-
-  <a mat-button routerLink="/board-creator" routerLinkActive="active-link">
-    <mat-icon>brush</mat-icon>
-    Create Board
-  </a>
-  <a mat-button routerLink="/lobby" routerLinkActive="active-link">
-    <mat-icon>videogame_asset</mat-icon>
-    Play
-  </a>
-  <a mat-button routerLink="/local" routerLinkActive="active-link">
-    <mat-icon>people</mat-icon>
-    Local Play
-  </a>
-</mat-toolbar>
+  <div class="nav-links">
+    <a class="nav-link" routerLink="/lobby" routerLinkActive="nav-link--active">
+      <mat-icon>videogame_asset</mat-icon>
+      <span>Online</span>
+    </a>
+    <a class="nav-link" routerLink="/local" routerLinkActive="nav-link--active">
+      <mat-icon>people</mat-icon>
+      <span>Local</span>
+    </a>
+    <a class="nav-link" routerLink="/board-creator" routerLinkActive="nav-link--active">
+      <mat-icon>brush</mat-icon>
+      <span>Editor</span>
+    </a>
+  </div>
+</nav>
 
 <main class="app-content">
   <router-outlet />

--- a/apps/client/src/app/app.scss
+++ b/apps/client/src/app/app.scss
@@ -5,26 +5,71 @@
   overflow: hidden;
 }
 
-mat-toolbar {
-  gap: 8px;
+.game-nav {
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  height: 52px;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
+}
+
+.nav-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.nav-pokeball {
+  filter: drop-shadow(0 0 8px rgba(230, 57, 70, 0.5));
+  flex-shrink: 0;
+}
+
+.nav-title {
+  font-family: var(--font-game);
+  font-size: 1.45rem;
+  letter-spacing: 2.5px;
+  color: var(--color-text);
+  line-height: 1;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: auto;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  text-decoration: none;
+  color: var(--color-text-muted);
+  font-size: 0.82rem;
+  font-weight: 500;
+  transition: all 0.18s ease;
+  border: 1px solid transparent;
 
   mat-icon {
-    margin-right: 4px;
+    font-size: 17px;
+    width: 17px;
+    height: 17px;
   }
-}
 
-.brand-text {
-  font-weight: 700;
-  margin-left: 8px;
-}
+  &:hover {
+    color: var(--color-text);
+    background: rgba(255, 255, 255, 0.05);
+  }
 
-.spacer {
-  flex: 1;
-}
-
-.active-link {
-  background: rgba(255, 255, 255, 0.1);
+  &--active {
+    color: var(--color-primary);
+    background: var(--color-primary-dim);
+    border-color: rgba(230, 57, 70, 0.25);
+  }
 }
 
 .app-content {

--- a/apps/client/src/app/app.spec.ts
+++ b/apps/client/src/app/app.spec.ts
@@ -20,7 +20,7 @@ describe('App', () => {
   it('should render the toolbar', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
-    const toolbar = fixture.nativeElement.querySelector('mat-toolbar');
+    const toolbar = fixture.nativeElement.querySelector('nav.game-nav');
     expect(toolbar).toBeTruthy();
   });
 
@@ -28,6 +28,6 @@ describe('App', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     const text = fixture.nativeElement.textContent;
-    expect(text).toContain('Pokemon Duel');
+    expect(text).toContain('POKEMON DUEL');
   });
 });

--- a/apps/client/src/app/app.ts
+++ b/apps/client/src/app/app.ts
@@ -1,12 +1,10 @@
 import { Component } from '@angular/core';
 import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
-import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, RouterLink, RouterLinkActive, MatToolbarModule, MatButtonModule, MatIconModule],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, MatIconModule],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })

--- a/apps/client/src/app/game/_game-shared.scss
+++ b/apps/client/src/app/game/_game-shared.scss
@@ -1,0 +1,139 @@
+// Shared layout and overlay styles for local-game and multiplayer-game components.
+
+:host {
+  display: block;
+  height: 100%;
+}
+
+.game-layout {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(4px, 1vw, 8px);
+  height: 100%;
+  box-sizing: border-box;
+  background: var(--color-bg);
+  overflow: hidden;
+  padding: clamp(4px, 1vw, 8px);
+}
+
+.board-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+// Game header — compact B2 bar
+.game-header {
+  display: flex;
+  align-items: center;
+  padding: 0 14px;
+  height: 46px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  margin-bottom: clamp(4px, 1vw, 8px);
+  flex-shrink: 0;
+  gap: 12px;
+}
+
+.header-brand {
+  font-family: var(--font-game);
+  font-size: 1.1rem;
+  letter-spacing: 2px;
+  color: var(--color-text);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.header-center {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+// Turn badge
+.turn-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 14px;
+  border-radius: 20px;
+  border: 1px solid transparent;
+  transition: all 0.25s ease;
+
+  &--p1 {
+    background: var(--color-player-1-dim);
+    border-color: rgba(59, 130, 246, 0.3);
+    color: var(--color-player-1);
+  }
+
+  &--p2 {
+    background: var(--color-player-2-dim);
+    border-color: rgba(239, 68, 68, 0.3);
+    color: var(--color-player-2);
+  }
+}
+
+.turn-badge__player {
+  font-family: var(--font-game);
+  font-size: 0.92rem;
+  letter-spacing: 1px;
+}
+
+.turn-badge__sep {
+  opacity: 0.4;
+  font-size: 0.7rem;
+}
+
+.turn-badge__label {
+  font-family: var(--font-game);
+  font-size: 0.92rem;
+  letter-spacing: 1px;
+}
+
+// Win overlay
+.win-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.87);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fade-in 0.3s ease;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.win-modal {
+  padding: 52px 72px;
+  border-radius: 20px;
+  text-align: center;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 0 0 1px var(--color-border), 0 28px 80px rgba(0, 0, 0, 0.7);
+  animation: pop-in 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+
+  h2 {
+    font-family: var(--font-game);
+    font-size: 3.2rem;
+    letter-spacing: 5px;
+    margin: 16px 0 8px;
+  }
+}
+
+@keyframes pop-in {
+  from { transform: scale(0.8); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+
+.win-message {
+  font-size: 1.05rem;
+  margin: 0 0 28px;
+  color: var(--color-text-muted);
+}

--- a/apps/client/src/app/game/game-board/battle-toast/battle-toast.component.html
+++ b/apps/client/src/app/game/game-board/battle-toast/battle-toast.component.html
@@ -1,25 +1,46 @@
-<div class="battle-toast">
-  <button class="battle-close" (click)="dismiss.emit()">
-    <mat-icon>close</mat-icon>
-  </button>
+<div class="battle-toast" (click)="dismiss.emit()">
   <div class="battle-header">
     <mat-icon>swords</mat-icon>
-    Battle!
+    <span>BATTLE</span>
+    <mat-icon>swords</mat-icon>
   </div>
-  <div class="battle-rolls">
-    <div class="battle-roll">
-      <span class="battle-pokemon">{{ getSpeciesName(getPokemonById(battle().attackerId)?.speciesId ?? '') }}</span>
-      <span class="battle-dice">{{ battle().attackerRoll }}{{ battle().attackerBonus > 0 ? ' +' + battle().attackerBonus : '' }}</span>
-      <span class="battle-total">= {{ battle().attackerRoll + battle().attackerBonus }}</span>
+
+  <div class="battle-body">
+    <div class="battle-side">
+      <span class="battle-pokemon-name">{{ getSpeciesName(getPokemonById(battle().attackerId)?.speciesId ?? '') }}</span>
+      <span class="type-badge" [class]="'type-badge--' + getSpeciesType(getPokemonById(battle().attackerId)?.speciesId ?? '')">
+        {{ getSpeciesType(getPokemonById(battle().attackerId)?.speciesId ?? '') }}
+      </span>
+      <div class="battle-roll-row">
+        <span class="battle-roll">{{ battle().attackerRoll }}</span>
+        @if (battle().attackerBonus > 0) {
+          <span class="battle-bonus">+{{ battle().attackerBonus }}</span>
+        }
+        <span class="battle-total">=&nbsp;{{ battle().attackerRoll + battle().attackerBonus }}</span>
+      </div>
     </div>
+
     <div class="battle-vs">VS</div>
-    <div class="battle-roll">
-      <span class="battle-pokemon">{{ getSpeciesName(getPokemonById(battle().defenderId)?.speciesId ?? '') }}</span>
-      <span class="battle-dice">{{ battle().defenderRoll }}{{ battle().defenderBonus > 0 ? ' +' + battle().defenderBonus : '' }}</span>
-      <span class="battle-total">= {{ battle().defenderRoll + battle().defenderBonus }}</span>
+
+    <div class="battle-side">
+      <span class="battle-pokemon-name">{{ getSpeciesName(getPokemonById(battle().defenderId)?.speciesId ?? '') }}</span>
+      <span class="type-badge" [class]="'type-badge--' + getSpeciesType(getPokemonById(battle().defenderId)?.speciesId ?? '')">
+        {{ getSpeciesType(getPokemonById(battle().defenderId)?.speciesId ?? '') }}
+      </span>
+      <div class="battle-roll-row">
+        <span class="battle-roll">{{ battle().defenderRoll }}</span>
+        @if (battle().defenderBonus > 0) {
+          <span class="battle-bonus">+{{ battle().defenderBonus }}</span>
+        }
+        <span class="battle-total">=&nbsp;{{ battle().defenderRoll + battle().defenderBonus }}</span>
+      </div>
     </div>
   </div>
+
   <div class="battle-result">
+    <mat-icon>emoji_events</mat-icon>
     {{ getSpeciesName(getPokemonById(battle().winnerId)?.speciesId ?? '') }} wins!
   </div>
+
+  <div class="battle-dismiss-hint">tap to dismiss</div>
 </div>

--- a/apps/client/src/app/game/game-board/battle-toast/battle-toast.component.scss
+++ b/apps/client/src/app/game/game-board/battle-toast/battle-toast.component.scss
@@ -1,102 +1,166 @@
 .battle-toast {
   position: fixed;
-  top: 80px;
+  top: 68px;
   left: 50%;
   transform: translateX(-50%);
-  background: var(--mat-sys-surface-container-high);
-  border-radius: 16px;
-  padding: 16px 24px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-  border: 1px solid var(--mat-sys-outline-variant);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-top: 2px solid var(--color-primary);
+  border-radius: 14px;
+  padding: 16px 28px 12px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6);
   z-index: 900;
-  min-width: 300px;
-  animation: slide-down 0.3s ease;
-}
-
-@keyframes slide-down {
-  from { transform: translateX(-50%) translateY(-100%); opacity: 0; }
-  to { transform: translateX(-50%) translateY(0); opacity: 1; }
-}
-
-.battle-close {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  background: none;
-  border: none;
+  min-width: 320px;
   cursor: pointer;
-  color: var(--mat-sys-on-surface-variant);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 4px;
-  border-radius: 50%;
+  animation: slide-down 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  user-select: none;
 
   &:hover {
-    background: var(--mat-sys-surface-container-highest);
+    border-color: rgba(230, 57, 70, 0.4);
   }
 }
 
+@keyframes slide-down {
+  from { transform: translateX(-50%) translateY(-110%); opacity: 0; }
+  to { transform: translateX(-50%) translateY(0); opacity: 1; }
+}
+
+// Header
 .battle-header {
-  text-align: center;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--mat-sys-error);
-  margin-bottom: 12px;
-  text-transform: uppercase;
-  letter-spacing: 1px;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 4px;
+  gap: 8px;
+  font-family: var(--font-game);
+  font-size: 1.1rem;
+  letter-spacing: 3px;
+  color: var(--color-primary);
+  margin-bottom: 14px;
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
 }
 
-.battle-rolls {
+// Body
+.battle-body {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 16px;
+  gap: 20px;
 }
 
-.battle-roll {
+.battle-side {
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 6px;
+  min-width: 100px;
+}
+
+.battle-pokemon-name {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--color-text);
+  text-align: center;
+}
+
+// Type badge
+.type-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+
+  &--normal {
+    background: rgba(148, 163, 184, 0.15);
+    color: var(--color-type-normal);
+    border: 1px solid rgba(148, 163, 184, 0.3);
+  }
+
+  &--water {
+    background: rgba(56, 189, 248, 0.15);
+    color: var(--color-type-water);
+    border: 1px solid rgba(56, 189, 248, 0.3);
+  }
+
+  &--fire {
+    background: rgba(251, 146, 60, 0.15);
+    color: var(--color-type-fire);
+    border: 1px solid rgba(251, 146, 60, 0.3);
+  }
+
+  &--grass {
+    background: rgba(74, 222, 128, 0.15);
+    color: var(--color-type-grass);
+    border: 1px solid rgba(74, 222, 128, 0.3);
+  }
+}
+
+.battle-roll-row {
+  display: flex;
+  align-items: baseline;
   gap: 4px;
 }
 
-.battle-pokemon {
-  font-size: 13px;
-  font-weight: 600;
+.battle-roll {
+  font-size: 2.4rem;
+  font-weight: 700;
+  color: var(--color-text);
+  line-height: 1;
 }
 
-.battle-dice {
-  font-size: 28px;
+.battle-bonus {
+  font-size: 1rem;
   font-weight: 700;
-  color: var(--mat-sys-primary);
+  color: var(--color-gold);
 }
 
 .battle-total {
-  font-size: 14px;
-  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.85rem;
   font-weight: 600;
-  margin-top: 4px;
-  padding-top: 4px;
-  border-top: 1px solid var(--mat-sys-outline-variant);
+  color: var(--color-text-muted);
 }
 
 .battle-vs {
-  font-size: 20px;
-  font-weight: 700;
-  color: var(--mat-sys-error);
+  font-family: var(--font-game);
+  font-size: 1.4rem;
+  letter-spacing: 2px;
+  color: var(--color-text-muted);
+  padding: 0 4px;
 }
 
+// Result
 .battle-result {
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   margin-top: 12px;
   padding-top: 12px;
-  border-top: 1px solid var(--mat-sys-outline-variant);
+  border-top: 1px solid var(--color-border);
   font-weight: 700;
-  font-size: 16px;
-  color: var(--mat-sys-primary);
+  font-size: 0.95rem;
+  color: var(--color-gold);
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    color: var(--color-gold);
+  }
+}
+
+.battle-dismiss-hint {
+  text-align: center;
+  margin-top: 8px;
+  font-size: 0.68rem;
+  color: var(--color-text-muted);
+  opacity: 0.6;
+  letter-spacing: 0.5px;
 }

--- a/apps/client/src/app/game/game-board/battle-toast/battle-toast.component.spec.ts
+++ b/apps/client/src/app/game/game-board/battle-toast/battle-toast.component.spec.ts
@@ -42,7 +42,7 @@ describe('BattleToastComponent', () => {
   describe('rendering', () => {
     it('should render battle header', () => {
       const header = fixture.nativeElement.querySelector('.battle-header');
-      expect(header?.textContent).toContain('Battle');
+      expect(header?.textContent).toContain('BATTLE');
     });
 
     it('should show attacker name (Charizard)', () => {
@@ -56,13 +56,13 @@ describe('BattleToastComponent', () => {
     });
 
     it('should show attacker dice roll', () => {
-      const rolls = fixture.nativeElement.querySelectorAll('.battle-dice');
+      const rolls = fixture.nativeElement.querySelectorAll('.battle-roll');
       const rollTexts = Array.from(rolls as NodeListOf<HTMLElement>).map((el) => el.textContent?.trim());
       expect(rollTexts.some((t) => t?.includes('5'))).toBe(true);
     });
 
     it('should show defender dice roll', () => {
-      const rolls = fixture.nativeElement.querySelectorAll('.battle-dice');
+      const rolls = fixture.nativeElement.querySelectorAll('.battle-roll');
       const rollTexts = Array.from(rolls as NodeListOf<HTMLElement>).map((el) => el.textContent?.trim());
       expect(rollTexts.some((t) => t?.includes('2'))).toBe(true);
     });
@@ -92,9 +92,9 @@ describe('BattleToastComponent', () => {
       fixture.componentRef.setInput('battle', battleWithBonus);
       fixture.detectChanges();
 
-      const rolls = fixture.nativeElement.querySelectorAll('.battle-dice');
-      const attackerRoll = rolls[0] as HTMLElement;
-      expect(attackerRoll.textContent).toContain('+1');
+      const bonuses = fixture.nativeElement.querySelectorAll('.battle-bonus');
+      const bonusTexts = Array.from(bonuses as NodeListOf<HTMLElement>).map((el) => el.textContent?.trim());
+      expect(bonusTexts.some((t) => t?.includes('+1'))).toBe(true);
     });
   });
 
@@ -103,10 +103,10 @@ describe('BattleToastComponent', () => {
   // ==========================================================================
 
   describe('dismiss', () => {
-    it('emits dismiss when close button is clicked', () => {
+    it('emits dismiss when toast is clicked', () => {
       const emitSpy = vi.spyOn(component.dismiss, 'emit');
-      const closeBtn = fixture.nativeElement.querySelector('.battle-close') as HTMLElement;
-      closeBtn.click();
+      const toast = fixture.nativeElement.querySelector('.battle-toast') as HTMLElement;
+      toast.click();
 
       expect(emitSpy).toHaveBeenCalled();
     });

--- a/apps/client/src/app/game/game-board/battle-toast/battle-toast.component.ts
+++ b/apps/client/src/app/game/game-board/battle-toast/battle-toast.component.ts
@@ -23,4 +23,8 @@ export class BattleToastComponent {
   protected getPokemonById(id: string): Pokemon | undefined {
     return this.pokemon().find((p) => p.id === id);
   }
+
+  protected getSpeciesType(speciesId: string): string {
+    return getSpecies(speciesId)?.type ?? 'normal';
+  }
 }

--- a/apps/client/src/app/game/game-board/game-board.component.scss
+++ b/apps/client/src/app/game/game-board/game-board.component.scss
@@ -7,7 +7,8 @@
 .board-canvas {
   flex: 1;
   position: relative;
-  background: var(--mat-sys-surface-container-low);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 12px;
   overflow: hidden;
   container-type: size;
@@ -16,6 +17,12 @@
   width: 100%;
   max-height: 100%;
   min-height: 0;
+
+  // Subtle grid texture
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.015) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.015) 1px, transparent 1px);
+  background-size: 40px 40px;
 }
 
 .bench-overlay {
@@ -30,63 +37,64 @@
 .bench-area {
   fill: none;
   stroke-width: 1.5;
+  stroke-dasharray: 6 4;
 
   &--player-1 {
-    stroke: #42a5f5;
-    fill: rgba(66, 165, 245, 0.06);
+    stroke: var(--color-player-1);
+    fill: rgba(59, 130, 246, 0.05);
   }
 
   &--player-2 {
-    stroke: #ef5350;
-    fill: rgba(239, 83, 80, 0.06);
+    stroke: var(--color-player-2);
+    fill: rgba(239, 68, 68, 0.05);
   }
 }
 
 .bench-connector {
   stroke-width: 1.5;
   stroke-dasharray: 4 3;
-  opacity: 0.7;
+  opacity: 0.5;
 
   &--player-1 {
-    stroke: #42a5f5;
+    stroke: var(--color-player-1);
   }
 
   &--player-2 {
-    stroke: #ef5350;
+    stroke: var(--color-player-2);
   }
 }
 
 .valid-target-indicator {
   position: absolute;
-  width: min(56px, 8cqmin);
-  height: min(56px, 8cqmin);
+  width: min(58px, 8.5cqmin);
+  height: min(58px, 8.5cqmin);
   border-radius: 50%;
-  border: max(2px, 0.3cqmin) dashed #4caf50;
-  background-color: rgba(76, 175, 80, 0.2);
+  border: max(2px, 0.35cqmin) dashed var(--color-success);
+  background-color: rgba(34, 197, 94, 0.15);
   transform: translate(-50%, -50%);
   cursor: pointer;
-  animation: pulse-target 1s infinite;
+  animation: pulse-target 1s ease-in-out infinite;
   z-index: 5;
 
   &:hover {
-    background-color: rgba(76, 175, 80, 0.4);
-    border-color: #2e7d32;
+    background-color: rgba(34, 197, 94, 0.3);
+    box-shadow: 0 0 12px rgba(34, 197, 94, 0.3);
   }
 
   &--battle {
-    border-color: #f44336;
-    background-color: rgba(244, 67, 54, 0.2);
+    border-color: var(--color-primary);
+    background-color: rgba(230, 57, 70, 0.15);
 
     &:hover {
-      background-color: rgba(244, 67, 54, 0.4);
-      border-color: #d32f2f;
+      background-color: rgba(230, 57, 70, 0.3);
+      box-shadow: 0 0 12px rgba(230, 57, 70, 0.3);
     }
   }
 }
 
 @keyframes pulse-target {
   0%, 100% { transform: translate(-50%, -50%) scale(1); opacity: 1; }
-  50% { transform: translate(-50%, -50%) scale(1.05); opacity: 0.8; }
+  50% { transform: translate(-50%, -50%) scale(1.08); opacity: 0.75; }
 }
 
 .battle-icon {
@@ -97,10 +105,9 @@
   height: 100%;
 
   mat-icon {
-    font-size: min(24px, 4cqmin);
-    width: min(24px, 4cqmin);
-    height: min(24px, 4cqmin);
-    color: #f44336;
+    font-size: min(22px, 3.8cqmin);
+    width: min(22px, 3.8cqmin);
+    height: min(22px, 3.8cqmin);
+    color: var(--color-primary);
   }
 }
-

--- a/apps/client/src/app/game/game-board/game-board.component.spec.ts
+++ b/apps/client/src/app/game/game-board/game-board.component.spec.ts
@@ -189,8 +189,8 @@ describe('GameBoardComponent', () => {
       fixture.detectChanges();
 
       const emitSpy = vi.spyOn(component.dismissBattle, 'emit');
-      const closeBtn = fixture.nativeElement.querySelector('.battle-close') as HTMLElement;
-      closeBtn.click();
+      const toast = fixture.nativeElement.querySelector('.battle-toast') as HTMLElement;
+      toast.click();
 
       expect(emitSpy).toHaveBeenCalled();
     });

--- a/apps/client/src/app/game/local-game/local-game.component.html
+++ b/apps/client/src/app/game/local-game/local-game.component.html
@@ -1,33 +1,41 @@
 <div class="game-layout">
+
   @if (phase() === 'ended' && winnerId()) {
     <div class="win-overlay" data-testid="win-overlay">
       <div class="win-modal">
         <mat-icon class="trophy-icon">emoji_events</mat-icon>
-        <h2>Victory!</h2>
-        <p class="win-message">Player {{ winnerId() }} wins!</p>
-        <button mat-flat-button data-testid="play-again-btn" (click)="resetGame()">Play Again</button>
+        <h2>VICTORY!</h2>
+        <p class="win-message">Player {{ winnerId() }} wins the battle!</p>
+        <button mat-flat-button data-testid="play-again-btn" (click)="resetGame()">
+          <mat-icon>replay</mat-icon>
+          Play Again
+        </button>
       </div>
     </div>
   }
 
   <main class="board-area">
     <div class="game-header">
-      <h2>Pokemon Duel</h2>
-      <div class="turn-indicator" data-testid="turn-indicator">
-        <span class="turn-label">Current Turn:</span>
-        <mat-chip
-          [class.turn-player--1]="currentPlayerId() === 1"
-          [class.turn-player--2]="currentPlayerId() === 2"
-        >
-          Player {{ currentPlayerId() }}
-        </mat-chip>
+      <span class="header-brand">POKEMON DUEL</span>
+
+      <div class="header-center">
+        <div
+          class="turn-badge"
+          [class.turn-badge--p1]="currentPlayerId() === 1"
+          [class.turn-badge--p2]="currentPlayerId() === 2"
+          data-testid="turn-indicator">
+          <span class="turn-badge__player">PLAYER {{ currentPlayerId() }}</span>
+          <span class="turn-badge__sep">·</span>
+          <span class="turn-badge__label">TURN</span>
+        </div>
       </div>
-      <div class="game-actions">
+
+      <div class="header-actions">
         <button mat-button data-testid="skip-turn-btn" (click)="skipTurn()" [disabled]="phase() === 'ended'">
           <mat-icon>skip_next</mat-icon>
-          Skip Turn
+          Skip
         </button>
-        <button mat-button color="warn" data-testid="reset-game-btn" (click)="resetGame()">
+        <button mat-button class="btn-reset" data-testid="reset-game-btn" (click)="resetGame()">
           <mat-icon>restart_alt</mat-icon>
           Reset
         </button>
@@ -55,8 +63,9 @@
     @if (selectedPokemonId() && phase() !== 'ended') {
       <div class="selection-info">
         <mat-icon>info</mat-icon>
-        <span>Pokemon selected! Click a highlighted spot to move. Red targets = battle!</span>
+        <span>Pokemon selected — click a highlighted spot to move. Red targets = battle!</span>
       </div>
     }
   </main>
+
 </div>

--- a/apps/client/src/app/game/local-game/local-game.component.scss
+++ b/apps/client/src/app/game/local-game/local-game.component.scss
@@ -9,7 +9,7 @@
   gap: clamp(4px, 1vw, 8px);
   height: 100%;
   box-sizing: border-box;
-  background: var(--mat-sys-surface);
+  background: var(--color-bg);
   overflow: hidden;
   padding: clamp(4px, 1vw, 8px);
 }
@@ -18,69 +18,108 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  order: 2;
   min-width: 0;
   min-height: 0;
 }
 
+// Game header — compact B2 bar
 .game-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 6px 10px;
-  background: var(--mat-sys-surface-container);
-  border-radius: 12px;
-  margin-bottom: 4px;
-  flex-wrap: wrap;
-  gap: 4px;
+  padding: 0 14px;
+  height: 46px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  margin-bottom: clamp(4px, 1vw, 8px);
+  flex-shrink: 0;
+  gap: 12px;
+}
+
+.header-brand {
+  font-family: var(--font-game);
+  font-size: 1.1rem;
+  letter-spacing: 2px;
+  color: var(--color-text);
+  white-space: nowrap;
   flex-shrink: 0;
 }
 
-.turn-indicator {
+.header-center {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.turn-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 14px;
+  border-radius: 20px;
+  border: 1px solid transparent;
+  transition: all 0.25s ease;
+
+  &--p1 {
+    background: var(--color-player-1-dim);
+    border-color: rgba(59, 130, 246, 0.3);
+    color: var(--color-player-1);
+  }
+
+  &--p2 {
+    background: var(--color-player-2-dim);
+    border-color: rgba(239, 68, 68, 0.3);
+    color: var(--color-player-2);
+  }
+}
+
+.turn-badge__player {
+  font-family: var(--font-game);
+  font-size: 0.92rem;
+  letter-spacing: 1px;
+}
+
+.turn-badge__sep {
+  opacity: 0.4;
+  font-size: 0.7rem;
+}
+
+.turn-badge__label {
+  font-family: var(--font-game);
+  font-size: 0.92rem;
+  letter-spacing: 1px;
+}
+
+.header-actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 2px;
+  flex-shrink: 0;
 }
 
-.turn-label {
-  color: var(--mat-sys-on-surface-variant);
-  font-size: 13px;
+.btn-reset {
+  color: var(--color-primary) !important;
 }
 
-.turn-player {
-  &--1 {
-    --mat-chip-label-text-color: #42a5f5;
-  }
-  &--2 {
-    --mat-chip-label-text-color: #ef5350;
-  }
-}
-
-.game-actions {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
+// Selection info banner
 .selection-info {
   margin-top: 4px;
-  padding: 6px 10px;
+  padding: 5px 12px;
   border-radius: 8px;
-  text-align: center;
-  font-size: 12px;
+  font-size: 0.75rem;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 6px;
-  background: color-mix(in srgb, var(--mat-sys-primary) 15%, transparent);
-  border: 1px solid color-mix(in srgb, var(--mat-sys-primary) 30%, transparent);
-  color: var(--mat-sys-primary);
+  background: rgba(59, 130, 246, 0.07);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  color: var(--color-player-1);
 
   mat-icon {
-    font-size: 16px;
-    width: 16px;
-    height: 16px;
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
   }
 }
 
@@ -88,7 +127,7 @@
 .win-overlay {
   position: fixed;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.8);
+  background: rgba(0, 0, 0, 0.87);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -102,25 +141,30 @@
 }
 
 .win-modal {
-  padding: 40px 60px;
-  border-radius: 24px;
+  padding: 52px 72px;
+  border-radius: 20px;
   text-align: center;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  background: var(--mat-sys-primary-container);
-  color: var(--mat-sys-on-primary-container);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 0 0 1px var(--color-border), 0 28px 80px rgba(0, 0, 0, 0.7);
   animation: pop-in 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 
   h2 {
-    font-size: 36px;
+    font-family: var(--font-game);
+    font-size: 3.2rem;
+    letter-spacing: 5px;
     margin: 16px 0 8px;
+    color: var(--color-gold);
+    text-shadow: 0 0 24px rgba(247, 215, 22, 0.5);
   }
 }
 
 .trophy-icon {
-  font-size: 64px;
-  width: 64px;
-  height: 64px;
-  color: #fdd835;
+  font-size: 72px !important;
+  width: 72px !important;
+  height: 72px !important;
+  color: var(--color-gold) !important;
+  filter: drop-shadow(0 0 16px rgba(247, 215, 22, 0.6));
 }
 
 @keyframes pop-in {
@@ -129,7 +173,7 @@
 }
 
 .win-message {
-  font-size: 20px;
-  margin: 0 0 24px;
-  opacity: 0.8;
+  font-size: 1.05rem;
+  margin: 0 0 28px;
+  color: var(--color-text-muted);
 }

--- a/apps/client/src/app/game/local-game/local-game.component.scss
+++ b/apps/client/src/app/game/local-game/local-game.component.scss
@@ -1,94 +1,4 @@
-:host {
-  display: block;
-  height: 100%;
-}
-
-.game-layout {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(4px, 1vw, 8px);
-  height: 100%;
-  box-sizing: border-box;
-  background: var(--color-bg);
-  overflow: hidden;
-  padding: clamp(4px, 1vw, 8px);
-}
-
-.board-area {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  min-height: 0;
-}
-
-// Game header — compact B2 bar
-.game-header {
-  display: flex;
-  align-items: center;
-  padding: 0 14px;
-  height: 46px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 10px;
-  margin-bottom: clamp(4px, 1vw, 8px);
-  flex-shrink: 0;
-  gap: 12px;
-}
-
-.header-brand {
-  font-family: var(--font-game);
-  font-size: 1.1rem;
-  letter-spacing: 2px;
-  color: var(--color-text);
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-.header-center {
-  flex: 1;
-  display: flex;
-  justify-content: center;
-}
-
-.turn-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 4px 14px;
-  border-radius: 20px;
-  border: 1px solid transparent;
-  transition: all 0.25s ease;
-
-  &--p1 {
-    background: var(--color-player-1-dim);
-    border-color: rgba(59, 130, 246, 0.3);
-    color: var(--color-player-1);
-  }
-
-  &--p2 {
-    background: var(--color-player-2-dim);
-    border-color: rgba(239, 68, 68, 0.3);
-    color: var(--color-player-2);
-  }
-}
-
-.turn-badge__player {
-  font-family: var(--font-game);
-  font-size: 0.92rem;
-  letter-spacing: 1px;
-}
-
-.turn-badge__sep {
-  opacity: 0.4;
-  font-size: 0.7rem;
-}
-
-.turn-badge__label {
-  font-family: var(--font-game);
-  font-size: 0.92rem;
-  letter-spacing: 1px;
-}
+@use '../game-shared';
 
 .header-actions {
   display: flex;
@@ -123,40 +33,10 @@
   }
 }
 
-// Win overlay
-.win-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.87);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  animation: fade-in 0.3s ease;
-}
-
-@keyframes fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-.win-modal {
-  padding: 52px 72px;
-  border-radius: 20px;
-  text-align: center;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  box-shadow: 0 0 0 1px var(--color-border), 0 28px 80px rgba(0, 0, 0, 0.7);
-  animation: pop-in 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-
-  h2 {
-    font-family: var(--font-game);
-    font-size: 3.2rem;
-    letter-spacing: 5px;
-    margin: 16px 0 8px;
-    color: var(--color-gold);
-    text-shadow: 0 0 24px rgba(247, 215, 22, 0.5);
-  }
+// Win modal colours (local game is always a victory)
+.win-modal h2 {
+  color: var(--color-gold);
+  text-shadow: 0 0 24px rgba(247, 215, 22, 0.5);
 }
 
 .trophy-icon {
@@ -165,15 +45,4 @@
   height: 72px !important;
   color: var(--color-gold) !important;
   filter: drop-shadow(0 0 16px rgba(247, 215, 22, 0.6));
-}
-
-@keyframes pop-in {
-  from { transform: scale(0.8); opacity: 0; }
-  to { transform: scale(1); opacity: 1; }
-}
-
-.win-message {
-  font-size: 1.05rem;
-  margin: 0 0 28px;
-  color: var(--color-text-muted);
 }

--- a/apps/client/src/app/game/local-game/local-game.component.spec.ts
+++ b/apps/client/src/app/game/local-game/local-game.component.spec.ts
@@ -315,7 +315,7 @@ describe('LocalGameComponent', () => {
       expect(gameStore.lastBattle()).toBeNull();
     });
 
-    it('battle toast auto-dismisses after 5 seconds', async () => {
+    it('battle toast auto-dismisses after 3 seconds', async () => {
       vi.useFakeTimers();
       try {
         triggerBattle(gameStore);
@@ -323,7 +323,7 @@ describe('LocalGameComponent', () => {
 
         expect(gameStore.lastBattle()).not.toBeNull();
 
-        vi.advanceTimersByTime(5000);
+        vi.advanceTimersByTime(3000);
 
         expect(gameStore.lastBattle()).toBeNull();
       } finally {

--- a/apps/client/src/app/game/local-game/local-game.component.ts
+++ b/apps/client/src/app/game/local-game/local-game.component.ts
@@ -10,13 +10,12 @@ import {
 import { GameStore, BoardService, Pokemon, Spot } from '@pokemon-duel/board';
 import { GameBoardComponent } from '../game-board/game-board.component';
 import { MatButtonModule } from '@angular/material/button';
-import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-local-game',
   standalone: true,
-  imports: [GameBoardComponent, MatButtonModule, MatChipsModule, MatIconModule],
+  imports: [GameBoardComponent, MatButtonModule, MatIconModule],
   providers: [GameStore],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './local-game.component.html',
@@ -61,7 +60,7 @@ export class LocalGameComponent {
       if (battle) {
         this.showBattle.set(true);
         if (this.battleDismissTimer) clearTimeout(this.battleDismissTimer);
-        this.battleDismissTimer = setTimeout(() => this.dismissBattle(), 5000);
+        this.battleDismissTimer = setTimeout(() => this.dismissBattle(), 3000);
       } else {
         this.showBattle.set(false);
       }

--- a/apps/client/src/app/game/multiplayer-game/multiplayer-game.component.html
+++ b/apps/client/src/app/game/multiplayer-game/multiplayer-game.component.html
@@ -1,17 +1,21 @@
 <div class="game-layout">
+
   @if (phase() === 'ended' && winnerId()) {
     <div class="win-overlay" data-testid="win-overlay">
-      <div class="win-modal" [class.victory]="localPlayerWon()" [class.defeat]="!localPlayerWon()">
+      <div class="win-modal" [class.win-modal--victory]="localPlayerWon()" [class.win-modal--defeat]="!localPlayerWon()">
         @if (localPlayerWon()) {
-          <mat-icon class="result-icon victory-icon">emoji_events</mat-icon>
-          <h2>Victory!</h2>
+          <mat-icon class="result-icon trophy-icon">emoji_events</mat-icon>
+          <h2>VICTORY!</h2>
           <p class="win-message">Congratulations! You won the battle!</p>
         } @else {
           <mat-icon class="result-icon defeat-icon">heart_broken</mat-icon>
-          <h2>Defeat</h2>
+          <h2>DEFEAT</h2>
           <p class="win-message">Your opponent captured your flag!</p>
         }
-        <button mat-flat-button data-testid="back-to-lobby-btn" (click)="returnToLobby()">Back to Lobby</button>
+        <button mat-flat-button data-testid="back-to-lobby-btn" (click)="returnToLobby()">
+          <mat-icon>arrow_back</mat-icon>
+          Back to Lobby
+        </button>
       </div>
     </div>
   }
@@ -19,31 +23,35 @@
   <main class="board-area">
     <div class="game-header">
       <div class="header-left">
-        <h2>Pokemon Duel</h2>
-        <span class="room-code">Room: {{ roomCode() }}</span>
+        <span class="header-brand">POKEMON DUEL</span>
+        <span class="room-badge">{{ roomCode() }}</span>
       </div>
-      <div class="turn-indicator">
+
+      <div class="header-center">
         @if (isMyTurn()) {
-          <mat-chip highlighted class="your-turn-chip">Your Turn!</mat-chip>
+          <div
+            class="turn-badge turn-badge--your-turn"
+            [class.turn-badge--p1]="currentPlayerId() === 1"
+            [class.turn-badge--p2]="currentPlayerId() === 2">
+            <span class="turn-badge__player">PLAYER {{ currentPlayerId() }}</span>
+            <span class="turn-badge__sep">·</span>
+            <span class="turn-badge__label">YOUR TURN</span>
+          </div>
         } @else {
-          <mat-chip class="opponent-turn-chip">Opponent's Turn</mat-chip>
+          <div
+            class="turn-badge turn-badge--waiting"
+            [class.turn-badge--p1]="currentPlayerId() === 1"
+            [class.turn-badge--p2]="currentPlayerId() === 2">
+            <span class="turn-badge__player">PLAYER {{ currentPlayerId() }}</span>
+            <span class="turn-badge__sep">·</span>
+            <span class="turn-badge__label">OPPONENT</span>
+          </div>
         }
-        <mat-chip
-          [class.turn-player--1]="currentPlayerId() === 1"
-          [class.turn-player--2]="currentPlayerId() === 2"
-        >
-          Player {{ currentPlayerId() }}
-        </mat-chip>
       </div>
-      <div class="player-info">
-        <span class="you-are">You are:</span>
-        <mat-chip
-          [class.player-badge--1]="localPlayerId() === 1"
-          [class.player-badge--2]="localPlayerId() === 2"
-        >
-          Player {{ localPlayerId() }}
-        </mat-chip>
-        <button mat-button color="warn" data-testid="leave-game-btn" (click)="returnToLobby()">
+
+      <div class="header-right">
+        <span class="you-label">You: P{{ localPlayerId() }}</span>
+        <button mat-button class="btn-leave" data-testid="leave-game-btn" (click)="returnToLobby()">
           <mat-icon>exit_to_app</mat-icon>
           Leave
         </button>
@@ -71,15 +79,16 @@
     @if (isMyTurn() && selectedPokemonId() && phase() !== 'ended') {
       <div class="selection-info">
         <mat-icon>info</mat-icon>
-        <span>Pokemon selected! Click a highlighted spot to move. Red targets = battle!</span>
+        <span>Pokemon selected — click a highlighted spot to move. Red targets = battle!</span>
       </div>
     }
 
     @if (!isMyTurn() && phase() === 'playing') {
       <div class="waiting-info">
         <mat-icon>hourglass_empty</mat-icon>
-        <span>Waiting for opponent to make their move...</span>
+        <span>Waiting for opponent's move...</span>
       </div>
     }
   </main>
+
 </div>

--- a/apps/client/src/app/game/multiplayer-game/multiplayer-game.component.scss
+++ b/apps/client/src/app/game/multiplayer-game/multiplayer-game.component.scss
@@ -1,54 +1,10 @@
-:host {
-  display: block;
-  height: 100%;
-}
-
-.game-layout {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(4px, 1vw, 8px);
-  height: 100%;
-  box-sizing: border-box;
-  background: var(--color-bg);
-  overflow: hidden;
-  padding: clamp(4px, 1vw, 8px);
-}
-
-.board-area {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  min-height: 0;
-}
-
-// Game header — compact B2 bar
-.game-header {
-  display: flex;
-  align-items: center;
-  padding: 0 14px;
-  height: 46px;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 10px;
-  margin-bottom: clamp(4px, 1vw, 8px);
-  flex-shrink: 0;
-  gap: 12px;
-}
+@use '../game-shared';
 
 .header-left {
   display: flex;
   align-items: center;
   gap: 10px;
   flex-shrink: 0;
-}
-
-.header-brand {
-  font-family: var(--font-game);
-  font-size: 1.1rem;
-  letter-spacing: 2px;
-  color: var(--color-text);
-  white-space: nowrap;
 }
 
 .room-badge {
@@ -63,33 +19,8 @@
   letter-spacing: 2px;
 }
 
-.header-center {
-  flex: 1;
-  display: flex;
-  justify-content: center;
-}
-
+// Extra turn-badge states for multiplayer (your-turn glow, waiting dim)
 .turn-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 4px 14px;
-  border-radius: 20px;
-  border: 1px solid transparent;
-  transition: all 0.25s ease;
-
-  &--p1 {
-    background: var(--color-player-1-dim);
-    border-color: rgba(59, 130, 246, 0.3);
-    color: var(--color-player-1);
-  }
-
-  &--p2 {
-    background: var(--color-player-2-dim);
-    border-color: rgba(239, 68, 68, 0.3);
-    color: var(--color-player-2);
-  }
-
   &--your-turn {
     animation: glow-turn 2s ease-in-out infinite;
   }
@@ -111,23 +42,6 @@
 @keyframes glow-turn-p2 {
   0%, 100% { box-shadow: none; }
   50% { box-shadow: 0 0 12px rgba(239, 68, 68, 0.4); }
-}
-
-.turn-badge__player {
-  font-family: var(--font-game);
-  font-size: 0.92rem;
-  letter-spacing: 1px;
-}
-
-.turn-badge__sep {
-  opacity: 0.4;
-  font-size: 0.7rem;
-}
-
-.turn-badge__label {
-  font-family: var(--font-game);
-  font-size: 0.92rem;
-  letter-spacing: 1px;
 }
 
 .header-right {
@@ -183,39 +97,8 @@
   color: var(--color-gold);
 }
 
-// Win overlay
-.win-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.87);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  animation: fade-in 0.3s ease;
-}
-
-@keyframes fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
+// Win modal: victory vs defeat colours
 .win-modal {
-  padding: 52px 72px;
-  border-radius: 20px;
-  text-align: center;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  box-shadow: 0 0 0 1px var(--color-border), 0 28px 80px rgba(0, 0, 0, 0.7);
-  animation: pop-in 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-
-  h2 {
-    font-family: var(--font-game);
-    font-size: 3.2rem;
-    letter-spacing: 5px;
-    margin: 16px 0 8px;
-  }
-
   &--victory h2 {
     color: var(--color-gold);
     text-shadow: 0 0 24px rgba(247, 215, 22, 0.5);
@@ -240,15 +123,4 @@
 .defeat-icon {
   color: var(--color-primary) !important;
   filter: drop-shadow(0 0 16px rgba(230, 57, 70, 0.4));
-}
-
-@keyframes pop-in {
-  from { transform: scale(0.8); opacity: 0; }
-  to { transform: scale(1); opacity: 1; }
-}
-
-.win-message {
-  font-size: 1.05rem;
-  margin: 0 0 28px;
-  color: var(--color-text-muted);
 }

--- a/apps/client/src/app/game/multiplayer-game/multiplayer-game.component.scss
+++ b/apps/client/src/app/game/multiplayer-game/multiplayer-game.component.scss
@@ -9,7 +9,7 @@
   gap: clamp(4px, 1vw, 8px);
   height: 100%;
   box-sizing: border-box;
-  background: var(--mat-sys-surface);
+  background: var(--color-bg);
   overflow: hidden;
   padding: clamp(4px, 1vw, 8px);
 }
@@ -18,95 +18,146 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  order: 2;
   min-width: 0;
   min-height: 0;
 }
 
+// Game header — compact B2 bar
 .game-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 6px 10px;
-  background: var(--mat-sys-surface-container);
-  border-radius: 12px;
-  margin-bottom: 4px;
-  flex-wrap: wrap;
-  gap: 4px;
+  padding: 0 14px;
+  height: 46px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  margin-bottom: clamp(4px, 1vw, 8px);
   flex-shrink: 0;
+  gap: 12px;
 }
 
 .header-left {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
+  flex-shrink: 0;
+}
 
-  h2 {
-    margin: 0;
-    font-size: 20px;
+.header-brand {
+  font-family: var(--font-game);
+  font-size: 1.1rem;
+  letter-spacing: 2px;
+  color: var(--color-text);
+  white-space: nowrap;
+}
+
+.room-badge {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--color-gold);
+  background: var(--color-gold-dim);
+  border: 1px solid rgba(247, 215, 22, 0.25);
+  border-radius: 6px;
+  padding: 2px 8px;
+  letter-spacing: 2px;
+}
+
+.header-center {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.turn-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 14px;
+  border-radius: 20px;
+  border: 1px solid transparent;
+  transition: all 0.25s ease;
+
+  &--p1 {
+    background: var(--color-player-1-dim);
+    border-color: rgba(59, 130, 246, 0.3);
+    color: var(--color-player-1);
   }
 
-  .room-code {
-    font-size: 0.85rem;
-    color: var(--mat-sys-on-surface-variant);
-    font-family: monospace;
+  &--p2 {
+    background: var(--color-player-2-dim);
+    border-color: rgba(239, 68, 68, 0.3);
+    color: var(--color-player-2);
+  }
+
+  &--your-turn {
+    animation: glow-turn 2s ease-in-out infinite;
+  }
+
+  &--waiting {
+    opacity: 0.6;
   }
 }
 
-.turn-indicator {
+@keyframes glow-turn {
+  0%, 100% { box-shadow: none; }
+  50% { box-shadow: 0 0 12px rgba(59, 130, 246, 0.4); }
+}
+
+.turn-badge--p2.turn-badge--your-turn {
+  animation: glow-turn-p2 2s ease-in-out infinite;
+}
+
+@keyframes glow-turn-p2 {
+  0%, 100% { box-shadow: none; }
+  50% { box-shadow: 0 0 12px rgba(239, 68, 68, 0.4); }
+}
+
+.turn-badge__player {
+  font-family: var(--font-game);
+  font-size: 0.92rem;
+  letter-spacing: 1px;
+}
+
+.turn-badge__sep {
+  opacity: 0.4;
+  font-size: 0.7rem;
+}
+
+.turn-badge__label {
+  font-family: var(--font-game);
+  font-size: 0.92rem;
+  letter-spacing: 1px;
+}
+
+.header-right {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-shrink: 0;
 }
 
-.your-turn-chip {
-  animation: glow-pulse 2s infinite;
+.you-label {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
 }
 
-@keyframes glow-pulse {
-  0%, 100% { box-shadow: 0 0 5px color-mix(in srgb, var(--mat-sys-primary) 50%, transparent); }
-  50% { box-shadow: 0 0 20px color-mix(in srgb, var(--mat-sys-primary) 80%, transparent); }
-}
+.btn-leave {
+  color: var(--color-text-muted) !important;
 
-.opponent-turn-chip {
-  opacity: 0.7;
-}
-
-.turn-player {
-  &--1 {
-    --mat-chip-label-text-color: #42a5f5;
-  }
-  &--2 {
-    --mat-chip-label-text-color: #ef5350;
+  &:hover {
+    color: var(--color-primary) !important;
   }
 }
 
-.player-info {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-
-  .you-are {
-    color: var(--mat-sys-on-surface-variant);
-    font-size: 13px;
-  }
-}
-
-.player-badge {
-  &--1 {
-    --mat-chip-label-text-color: #42a5f5;
-  }
-  &--2 {
-    --mat-chip-label-text-color: #ef5350;
-  }
-}
-
-.selection-info, .waiting-info {
+// Info banners
+.selection-info,
+.waiting-info {
   margin-top: 4px;
-  padding: 6px 10px;
+  padding: 5px 12px;
   border-radius: 8px;
-  text-align: center;
-  font-size: 12px;
+  font-size: 0.75rem;
   flex-shrink: 0;
   display: flex;
   align-items: center;
@@ -114,29 +165,29 @@
   gap: 6px;
 
   mat-icon {
-    font-size: 16px;
-    width: 16px;
-    height: 16px;
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
   }
 }
 
 .selection-info {
-  background: color-mix(in srgb, var(--mat-sys-primary) 15%, transparent);
-  border: 1px solid color-mix(in srgb, var(--mat-sys-primary) 30%, transparent);
-  color: var(--mat-sys-primary);
+  background: rgba(59, 130, 246, 0.07);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  color: var(--color-player-1);
 }
 
 .waiting-info {
-  background: color-mix(in srgb, var(--mat-sys-tertiary) 15%, transparent);
-  border: 1px solid color-mix(in srgb, var(--mat-sys-tertiary) 30%, transparent);
-  color: var(--mat-sys-tertiary);
+  background: rgba(247, 215, 22, 0.07);
+  border: 1px solid rgba(247, 215, 22, 0.2);
+  color: var(--color-gold);
 }
 
 // Win overlay
 .win-overlay {
   position: fixed;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.8);
+  background: rgba(0, 0, 0, 0.87);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -150,40 +201,45 @@
 }
 
 .win-modal {
-  padding: 40px 60px;
-  border-radius: 24px;
+  padding: 52px 72px;
+  border-radius: 20px;
   text-align: center;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 0 0 1px var(--color-border), 0 28px 80px rgba(0, 0, 0, 0.7);
   animation: pop-in 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 
-  &.victory {
-    background: var(--mat-sys-primary-container);
-    color: var(--mat-sys-on-primary-container);
-  }
-
-  &.defeat {
-    background: var(--mat-sys-error-container);
-    color: var(--mat-sys-on-error-container);
-  }
-
   h2 {
-    font-size: 36px;
+    font-family: var(--font-game);
+    font-size: 3.2rem;
+    letter-spacing: 5px;
     margin: 16px 0 8px;
+  }
+
+  &--victory h2 {
+    color: var(--color-gold);
+    text-shadow: 0 0 24px rgba(247, 215, 22, 0.5);
+  }
+
+  &--defeat h2 {
+    color: var(--color-primary);
   }
 }
 
 .result-icon {
-  font-size: 64px;
-  width: 64px;
-  height: 64px;
+  font-size: 72px !important;
+  width: 72px !important;
+  height: 72px !important;
 }
 
-.victory-icon {
-  color: #fdd835;
+.trophy-icon {
+  color: var(--color-gold) !important;
+  filter: drop-shadow(0 0 16px rgba(247, 215, 22, 0.6));
 }
 
 .defeat-icon {
-  color: var(--mat-sys-error);
+  color: var(--color-primary) !important;
+  filter: drop-shadow(0 0 16px rgba(230, 57, 70, 0.4));
 }
 
 @keyframes pop-in {
@@ -192,7 +248,7 @@
 }
 
 .win-message {
-  font-size: 20px;
-  margin: 0 0 24px;
-  opacity: 0.8;
+  font-size: 1.05rem;
+  margin: 0 0 28px;
+  color: var(--color-text-muted);
 }

--- a/apps/client/src/app/game/multiplayer-game/multiplayer-game.component.spec.ts
+++ b/apps/client/src/app/game/multiplayer-game/multiplayer-game.component.spec.ts
@@ -325,7 +325,7 @@ describe('MultiplayerGameComponent', () => {
       store.setGameState(makeGameState({ winnerId: 1, phase: 'ended' }));
       fixture.detectChanges();
 
-      expect(fixture.nativeElement.textContent).toContain('Victory!');
+      expect(fixture.nativeElement.textContent).toContain('VICTORY!');
     });
 
     it('shows Defeat when winnerId does not equal localPlayerId', () => {
@@ -333,7 +333,7 @@ describe('MultiplayerGameComponent', () => {
       store.setGameState(makeGameState({ winnerId: 2, phase: 'ended' }));
       fixture.detectChanges();
 
-      expect(fixture.nativeElement.textContent).toContain('Defeat');
+      expect(fixture.nativeElement.textContent).toContain('DEFEAT');
     });
   });
 

--- a/apps/client/src/app/game/multiplayer-game/multiplayer-game.component.ts
+++ b/apps/client/src/app/game/multiplayer-game/multiplayer-game.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  DestroyRef,
   effect,
   inject,
   linkedSignal,
@@ -13,13 +14,12 @@ import { MultiplayerService } from '../../multiplayer/multiplayer.service';
 import { MultiplayerStore } from '../../multiplayer/multiplayer.store';
 import { GameBoardComponent } from '../game-board/game-board.component';
 import { MatButtonModule } from '@angular/material/button';
-import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-multiplayer-game',
   standalone: true,
-  imports: [GameBoardComponent, MatButtonModule, MatChipsModule, MatIconModule],
+  imports: [GameBoardComponent, MatButtonModule, MatIconModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './multiplayer-game.component.html',
   styleUrl: './multiplayer-game.component.scss',
@@ -29,6 +29,7 @@ export class MultiplayerGameComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly multiplayer = inject(MultiplayerService);
   private readonly store = inject(MultiplayerStore);
+  private readonly destroyRef = inject(DestroyRef);
 
   protected readonly roomCode = this.store.roomCode;
   protected readonly localPlayerId = this.store.localPlayerId;
@@ -66,6 +67,24 @@ export class MultiplayerGameComponent implements OnInit {
       this.router.navigate(['/lobby']);
     }
   });
+
+  private battleDismissTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private readonly battleDismissEffect = effect(() => {
+    const battle = this.store.lastBattle();
+    if (battle) {
+      if (this.battleDismissTimer) clearTimeout(this.battleDismissTimer);
+      this.battleDismissTimer = setTimeout(() => {
+        this.displayBattle.set(null);
+      }, 3000);
+    }
+  });
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      if (this.battleDismissTimer) clearTimeout(this.battleDismissTimer);
+    });
+  }
 
   ngOnInit(): void {
     const roomId = this.route.snapshot.paramMap.get('roomId');

--- a/apps/client/src/app/game/passage/passage.component.scss
+++ b/apps/client/src/app/game/passage/passage.component.scss
@@ -2,14 +2,14 @@
   display: contents;
 }
 
-$color-normal: #9e9e9e;
-$color-normal-hover: #bdbdbd;
-$color-water: #42a5f5;
-$color-water-hover: #64b5f6;
-$color-fire: #ef5350;
-$color-fire-hover: #e57373;
-$color-grass: #66bb6a;
-$color-grass-hover: #81c784;
+$color-normal: #4B5563;
+$color-normal-hover: #6B7280;
+$color-water: #38BDF8;
+$color-water-hover: #7DD3FC;
+$color-fire: #FB923C;
+$color-fire-hover: #FDBA74;
+$color-grass: #4ADE80;
+$color-grass-hover: #86EFAC;
 
 .passage-svg {
   position: absolute;
@@ -23,11 +23,11 @@ $color-grass-hover: #81c784;
 
 .passage-line {
   stroke: $color-normal;
-  stroke-width: 3;
+  stroke-width: 3.5;
   stroke-linecap: round;
   pointer-events: stroke;
   cursor: pointer;
-  transition: stroke 0.15s ease, stroke-width 0.15s ease;
+  transition: stroke 0.15s ease, stroke-width 0.15s ease, filter 0.15s ease;
 
   &:hover {
     stroke: $color-normal-hover;
@@ -41,23 +41,35 @@ $color-grass-hover: #81c784;
 
   &.passage--water {
     stroke: $color-water;
-    &:hover { stroke: $color-water-hover; }
+    filter: drop-shadow(0 0 3px rgba(56, 189, 248, 0.4));
+    &:hover {
+      stroke: $color-water-hover;
+      filter: drop-shadow(0 0 5px rgba(56, 189, 248, 0.6));
+    }
   }
 
   &.passage--fire {
     stroke: $color-fire;
-    &:hover { stroke: $color-fire-hover; }
+    filter: drop-shadow(0 0 3px rgba(251, 146, 60, 0.4));
+    &:hover {
+      stroke: $color-fire-hover;
+      filter: drop-shadow(0 0 5px rgba(251, 146, 60, 0.6));
+    }
   }
 
   &.passage--grass {
     stroke: $color-grass;
-    &:hover { stroke: $color-grass-hover; }
+    filter: drop-shadow(0 0 3px rgba(74, 222, 128, 0.4));
+    &:hover {
+      stroke: $color-grass-hover;
+      filter: drop-shadow(0 0 5px rgba(74, 222, 128, 0.6));
+    }
   }
 
   &.passage--selected {
-    stroke-width: 4;
-    filter: drop-shadow(0 0 4px color-mix(in srgb, var(--mat-sys-primary) 50%, transparent));
+    stroke-width: 5;
+    filter: drop-shadow(0 0 6px rgba(247, 215, 22, 0.6));
 
-    &:hover { stroke-width: 5; }
+    &:hover { stroke-width: 6; }
   }
 }

--- a/apps/client/src/app/game/pokemon/pokemon.component.scss
+++ b/apps/client/src/app/game/pokemon/pokemon.component.scss
@@ -1,4 +1,4 @@
-$pokemon-size: min(48px, 7cqmin);
+$pokemon-size: min(50px, 7.5cqmin);
 $pokemon-border: max(2px, 0.4cqmin);
 
 .pokemon {
@@ -6,8 +6,8 @@ $pokemon-border: max(2px, 0.4cqmin);
   width: $pokemon-size;
   height: $pokemon-size;
   border-radius: 50%;
-  border: $pokemon-border solid var(--mat-sys-outline);
-  background-color: var(--mat-sys-surface-container-highest);
+  border: $pokemon-border solid var(--color-border-strong);
+  background-color: var(--color-surface-elevated);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -19,43 +19,49 @@ $pokemon-border: max(2px, 0.4cqmin);
   z-index: 2;
 
   &:hover {
-    transform: translate(-50%, -50%) scale(1.15);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    transform: translate(-50%, -50%) scale(1.18);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.5);
     z-index: 10;
   }
 
   // Type-based backgrounds
   &--normal {
-    background-color: var(--mat-sys-surface-container);
+    background-color: var(--color-surface-elevated);
   }
 
   &--water {
-    background-color: rgba(33, 150, 243, 0.15);
+    background: radial-gradient(circle at 60% 40%, rgba(56, 189, 248, 0.25), var(--color-surface-elevated) 70%);
   }
 
   &--fire {
-    background-color: rgba(244, 67, 54, 0.15);
+    background: radial-gradient(circle at 60% 40%, rgba(251, 146, 60, 0.25), var(--color-surface-elevated) 70%);
   }
 
   &--grass {
-    background-color: rgba(76, 175, 80, 0.15);
+    background: radial-gradient(circle at 60% 40%, rgba(74, 222, 128, 0.25), var(--color-surface-elevated) 70%);
   }
 
-  // Player-based border color
+  // Player-based border
   &--player-1 {
-    border-color: #42a5f5;
+    border-color: var(--color-player-1);
   }
 
   &--player-2 {
-    border-color: #ef5350;
+    border-color: var(--color-player-2);
   }
 
+  // Selected state — dramatic gold glow
   &--selected {
-    box-shadow: 0 0 0 max(3px, 0.5cqmin) rgba(255, 215, 0, 0.9), 0 0 min(12px, 2cqmin) rgba(255, 215, 0, 0.6);
-    transform: translate(-50%, -50%) scale(1.1);
+    box-shadow:
+      0 0 0 max(3px, 0.5cqmin) rgba(247, 215, 22, 0.9),
+      0 0 min(16px, 2.5cqmin) rgba(247, 215, 22, 0.5);
+    transform: translate(-50%, -50%) scale(1.12);
+    z-index: 10;
 
     &:hover {
-      box-shadow: 0 0 0 max(3px, 0.5cqmin) rgba(255, 215, 0, 1), 0 0 min(16px, 2.5cqmin) rgba(255, 215, 0, 0.8);
+      box-shadow:
+        0 0 0 max(3px, 0.5cqmin) rgba(247, 215, 22, 1),
+        0 0 min(22px, 3cqmin) rgba(247, 215, 22, 0.7);
     }
   }
 
@@ -74,21 +80,36 @@ $pokemon-border: max(2px, 0.4cqmin);
 
 .pokemon-movement {
   position: absolute;
-  bottom: -2px;
-  right: -2px;
-  min-width: min(16px, 2.5cqmin);
-  height: min(16px, 2.5cqmin);
-  border-radius: min(8px, 1.25cqmin);
-  background-color: var(--mat-sys-outline);
-  color: var(--mat-sys-on-primary);
+  bottom: -1px;
+  right: -1px;
+  min-width: min(17px, 2.6cqmin);
+  height: min(17px, 2.6cqmin);
+  border-radius: min(9px, 1.4cqmin);
+  background-color: var(--color-surface-highest);
+  color: var(--color-text);
   font-size: min(10px, 1.5cqmin);
   font-weight: 700;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0 max(2px, 0.3cqmin);
+  border: 1px solid var(--color-border-strong);
 
-  .pokemon--water & { background-color: #1976d2; }
-  .pokemon--fire & { background-color: #d32f2f; }
-  .pokemon--grass & { background-color: #388e3c; }
+  .pokemon--water & {
+    background-color: #0369A1;
+    color: white;
+    border-color: var(--color-type-water);
+  }
+
+  .pokemon--fire & {
+    background-color: #C2410C;
+    color: white;
+    border-color: var(--color-type-fire);
+  }
+
+  .pokemon--grass & {
+    background-color: #15803D;
+    color: white;
+    border-color: var(--color-type-grass);
+  }
 }

--- a/apps/client/src/app/game/spot/spot.component.scss
+++ b/apps/client/src/app/game/spot/spot.component.scss
@@ -6,53 +6,73 @@ $spot-border-width: max(2px, 0.4cqmin);
   width: $spot-size;
   height: $spot-size;
   border-radius: 50%;
-  border: $spot-border-width solid var(--mat-sys-outline);
-  background-color: var(--mat-sys-surface-container-high);
+  border: $spot-border-width solid var(--color-border-strong);
+  background-color: var(--color-surface-elevated);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   transform: translate(-50%, -50%);
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
   user-select: none;
 
   &:hover {
-    transform: translate(-50%, -50%) scale(1.1);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    transform: translate(-50%, -50%) scale(1.12);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.4);
+    border-color: rgba(255, 255, 255, 0.3);
   }
 
   &--normal {
-    background-color: var(--mat-sys-surface-container);
-    border-color: var(--mat-sys-outline);
+    background-color: var(--color-surface-elevated);
+    border-color: var(--color-border-strong);
   }
 
   &--entry {
-    background-color: var(--mat-sys-surface-container-highest);
-    border-color: #ef5350;
-    border-width: 2px;
+    background-color: var(--color-surface-highest);
+    border-color: var(--color-primary);
+    border-width: $spot-border-width;
+    box-shadow: 0 0 8px rgba(230, 57, 70, 0.2);
   }
 
   &--flag {
-    background-color: rgba(249, 168, 37, 0.15);
-    border-color: #f9a825;
+    background-color: var(--color-gold-dim);
+    border-color: var(--color-gold);
+    box-shadow: 0 0 8px rgba(247, 215, 22, 0.2);
   }
 
   &--bench {
-    background-color: var(--mat-sys-surface-container);
+    background-color: var(--color-surface-elevated);
     border-style: dashed;
-    opacity: 0.5;
+    opacity: 0.45;
   }
 
-  &--player-1 { border-style: dashed; border-color: #42a5f5; }
-  &--player-2 { border-style: dashed; border-color: #ef5350; }
-  &--player-3 { border-style: dotted; border-color: #66bb6a; border-width: 4px; }
-  &--player-4 { border-style: double; border-color: #ab47bc; border-width: 5px; }
+  &--player-1 {
+    border-style: dashed;
+    border-color: var(--color-player-1);
+  }
+
+  &--player-2 {
+    border-style: dashed;
+    border-color: var(--color-player-2);
+  }
+
+  &--player-3 {
+    border-style: dotted;
+    border-color: #4ADE80;
+    border-width: 4px;
+  }
+
+  &--player-4 {
+    border-style: double;
+    border-color: #C084FC;
+    border-width: 5px;
+  }
 
   &--selected {
-    box-shadow: 0 0 0 4px color-mix(in srgb, var(--mat-sys-primary) 50%, transparent);
+    box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.4);
 
     &:hover {
-      box-shadow: 0 0 0 4px color-mix(in srgb, var(--mat-sys-primary) 70%, transparent);
+      box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.6);
     }
   }
 }
@@ -60,7 +80,7 @@ $spot-border-width: max(2px, 0.4cqmin);
 .spot-name {
   font-size: min(10px, 1.5cqmin);
   font-weight: 600;
-  color: var(--mat-sys-on-surface);
+  color: var(--color-text);
   text-align: center;
   max-width: 90%;
   overflow: hidden;
@@ -94,8 +114,8 @@ $spot-border-width: max(2px, 0.4cqmin);
   width: min(14px, 2cqmin);
   height: min(14px, 2cqmin);
   border-radius: 50%;
-  background-color: var(--mat-sys-outline);
-  color: var(--mat-sys-on-primary);
+  background-color: var(--color-border-strong);
+  color: white;
   font-size: min(9px, 1.3cqmin);
   font-weight: 700;
   display: flex;
@@ -103,8 +123,8 @@ $spot-border-width: max(2px, 0.4cqmin);
   justify-content: center;
   line-height: 1;
 
-  .spot--player-1 & { background-color: #42a5f5; }
-  .spot--player-2 & { background-color: #ef5350; }
-  .spot--player-3 & { background-color: #66bb6a; }
-  .spot--player-4 & { background-color: #ab47bc; }
+  .spot--player-1 & { background-color: var(--color-player-1); }
+  .spot--player-2 & { background-color: var(--color-player-2); }
+  .spot--player-3 & { background-color: var(--color-type-grass); }
+  .spot--player-4 & { background-color: #C084FC; }
 }

--- a/apps/client/src/app/lobby/lobby/lobby.component.html
+++ b/apps/client/src/app/lobby/lobby/lobby.component.html
@@ -77,7 +77,7 @@
               (input)="updateJoinCode($event)"
               maxlength="4"
               [disabled]="isLoading()"
-              style="text-transform: uppercase; letter-spacing: 0.5rem; text-align: center; font-size: 1.3rem; font-weight: 700;">
+>
             <mat-icon matPrefix>tag</mat-icon>
           </mat-form-field>
           <button

--- a/apps/client/src/app/lobby/lobby/lobby.component.html
+++ b/apps/client/src/app/lobby/lobby/lobby.component.html
@@ -1,50 +1,73 @@
-<div class="lobby-container">
-  <div class="lobby-header">
-    <h1>Pokemon Duel</h1>
-    <p>Challenge your friends in real-time battles!</p>
+<div class="lobby-page">
+
+  <!-- Decorative background watermark -->
+  <div class="lobby-bg" aria-hidden="true">
+    <svg class="lobby-bg-pokeball" viewBox="0 0 200 200">
+      <circle cx="100" cy="100" r="96" fill="none" stroke="rgba(230,57,70,0.06)" stroke-width="4"/>
+      <path d="M4 100 A96 96 0 0 1 196 100 Z" fill="rgba(230,57,70,0.04)"/>
+      <line x1="4" y1="100" x2="196" y2="100" stroke="rgba(230,57,70,0.07)" stroke-width="4"/>
+      <circle cx="100" cy="100" r="26" fill="none" stroke="rgba(230,57,70,0.07)" stroke-width="4"/>
+    </svg>
   </div>
 
-  @if (error()) {
-    <div class="error-banner">
-      <mat-icon>warning</mat-icon>
-      <span>{{ error() }}</span>
-    </div>
-  }
+  <div class="lobby-content">
 
-  @if (!isInRoom()) {
-    <div class="lobby-cards">
-      <mat-card appearance="outlined" class="lobby-card">
-        <mat-card-header>
-          <mat-icon mat-card-avatar class="card-avatar">meeting_room</mat-icon>
-          <mat-card-title>Create Room</mat-card-title>
-          <mat-card-subtitle>Start a new game</mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-content>
-          <p>Create a room and invite a friend to join with a room code.</p>
-        </mat-card-content>
-        <mat-card-actions>
+    <!-- Hero section -->
+    <div class="lobby-hero">
+      <div class="hero-icon" aria-hidden="true">
+        <svg viewBox="0 0 64 64" width="64" height="64">
+          <circle cx="32" cy="32" r="30" fill="white" stroke="#222" stroke-width="2"/>
+          <path d="M2 32 A30 30 0 0 1 62 32 Z" fill="#E63946"/>
+          <line x1="2" y1="32" x2="62" y2="32" stroke="#222" stroke-width="3"/>
+          <circle cx="32" cy="32" r="9" fill="white" stroke="#222" stroke-width="3"/>
+        </svg>
+      </div>
+      <h1 class="hero-title">POKEMON DUEL</h1>
+      <p class="hero-subtitle">Challenge a trainer to battle</p>
+    </div>
+
+    @if (error()) {
+      <div class="alert-error">
+        <mat-icon>warning</mat-icon>
+        <span>{{ error() }}</span>
+      </div>
+    }
+
+    @if (!isInRoom()) {
+      <div class="lobby-actions">
+
+        <!-- Create Room -->
+        <div class="action-card">
+          <div class="action-card__icon action-card__icon--create">
+            <mat-icon>add_circle</mat-icon>
+          </div>
+          <h2 class="action-card__title">Create Room</h2>
+          <p class="action-card__desc">Start a new game and invite a friend with a room code</p>
           <button
-            mat-flat-button
+            class="action-btn action-btn--primary"
             data-testid="create-room-btn"
             [disabled]="isLoading()"
             (click)="createRoom()">
             @if (isLoading() && roomState() === 'creating') {
-              <mat-spinner diameter="20"></mat-spinner>
+              <mat-spinner diameter="18"></mat-spinner>
+              Creating...
+            } @else {
+              <mat-icon>add</mat-icon>
+              Create Room
             }
-            {{ isLoading() && roomState() === 'creating' ? 'Creating...' : 'Create New Room' }}
           </button>
-        </mat-card-actions>
-      </mat-card>
+        </div>
 
-      <mat-card appearance="outlined" class="lobby-card">
-        <mat-card-header>
-          <mat-icon mat-card-avatar class="card-avatar">login</mat-icon>
-          <mat-card-title>Join Room</mat-card-title>
-          <mat-card-subtitle>Enter a room code</mat-card-subtitle>
-        </mat-card-header>
-        <mat-card-content>
-          <p>Enter a room code to join a friend's game.</p>
-          <mat-form-field appearance="outline" class="room-code-field">
+        <div class="actions-divider"><span>OR</span></div>
+
+        <!-- Join Room -->
+        <div class="action-card">
+          <div class="action-card__icon action-card__icon--join">
+            <mat-icon>login</mat-icon>
+          </div>
+          <h2 class="action-card__title">Join Room</h2>
+          <p class="action-card__desc">Enter a room code to join a friend's game</p>
+          <mat-form-field appearance="outline" class="code-field">
             <mat-label>Room Code</mat-label>
             <input
               matInput
@@ -54,73 +77,80 @@
               (input)="updateJoinCode($event)"
               maxlength="4"
               [disabled]="isLoading()"
-              style="text-transform: uppercase; letter-spacing: 0.3rem; text-align: center;">
+              style="text-transform: uppercase; letter-spacing: 0.5rem; text-align: center; font-size: 1.3rem; font-weight: 700;">
             <mat-icon matPrefix>tag</mat-icon>
           </mat-form-field>
-        </mat-card-content>
-        <mat-card-actions>
           <button
-            mat-flat-button
+            class="action-btn action-btn--secondary"
             data-testid="join-room-btn"
             [disabled]="isLoading() || !joinCode()"
             (click)="joinRoom()">
             @if (isLoading() && roomState() === 'joining') {
-              <mat-spinner diameter="20"></mat-spinner>
+              <mat-spinner diameter="18"></mat-spinner>
+              Joining...
+            } @else {
+              <mat-icon>arrow_forward</mat-icon>
+              Join Room
             }
-            {{ isLoading() && roomState() === 'joining' ? 'Joining...' : 'Join' }}
           </button>
-        </mat-card-actions>
-      </mat-card>
-    </div>
-  } @else {
-    <div class="waiting-room">
-      <mat-card appearance="outlined" class="waiting-card">
+        </div>
+
+      </div>
+    } @else {
+
+      <!-- Waiting / Ready state -->
+      <div class="waiting-area">
         @if (isWaiting()) {
-          <mat-card-content class="waiting-content">
-            <mat-spinner diameter="48"></mat-spinner>
-            <h2>Waiting for Opponent</h2>
-
-            <div class="room-code-display">
-              <span class="code-label">Room Code</span>
-              <div class="code-box">
-                <span class="code-text" data-testid="room-code">{{ roomCode() }}</span>
-                <button mat-icon-button (click)="copyRoomCode()" aria-label="Copy code">
-                  <mat-icon>content_copy</mat-icon>
-                </button>
-              </div>
+          <div class="waiting-card">
+            <div class="waiting-pokeball" aria-hidden="true">
+              <svg viewBox="0 0 48 48" width="48" height="48">
+                <circle cx="24" cy="24" r="22" fill="white" stroke="#333" stroke-width="2"/>
+                <path d="M2 24 A22 22 0 0 1 46 24 Z" fill="#E63946"/>
+                <line x1="2" y1="24" x2="46" y2="24" stroke="#333" stroke-width="2.5"/>
+                <circle cx="24" cy="24" r="7" fill="white" stroke="#333" stroke-width="2.5"/>
+              </svg>
             </div>
-
-            <p class="waiting-hint">Share this code with your friend to start the battle!</p>
-
-            <mat-chip highlighted>
-              <mat-icon matChipAvatar>person</mat-icon>
+            <h2 class="waiting-title">Waiting for Opponent</h2>
+            <p class="waiting-hint">Share this code with your friend</p>
+            <div class="room-code-block">
+              <span class="room-code-value" data-testid="room-code">{{ roomCode() }}</span>
+              <button class="copy-btn" (click)="copyRoomCode()" aria-label="Copy room code">
+                <mat-icon>content_copy</mat-icon>
+              </button>
+            </div>
+            <div class="player-pill">
+              <mat-icon>person</mat-icon>
               You are Player {{ localPlayerId() }}
-            </mat-chip>
-          </mat-card-content>
+            </div>
+          </div>
         } @else {
-          <mat-card-content class="ready-content">
-            <mat-icon class="ready-icon">check_circle</mat-icon>
-            <h2>Opponent Connected!</h2>
-            <p>Both players are ready. Let the battle begin!</p>
-
-            <button mat-flat-button class="start-btn" (click)="navigateToGame()">
+          <div class="ready-card">
+            <div class="ready-icon">
+              <mat-icon>check_circle</mat-icon>
+            </div>
+            <h2 class="ready-title">Opponent Connected!</h2>
+            <p class="ready-hint">Both trainers are ready. Let the battle begin!</p>
+            <button class="action-btn action-btn--battle" (click)="navigateToGame()">
+              <mat-icon>sports_esports</mat-icon>
               Start Battle!
             </button>
-          </mat-card-content>
+          </div>
         }
 
-        <mat-card-actions>
-          <button mat-button data-testid="leave-room-btn" (click)="leaveRoom()">
-            Leave Room
-          </button>
-        </mat-card-actions>
-      </mat-card>
-    </div>
-  }
+        <button class="leave-btn" data-testid="leave-room-btn" (click)="leaveRoom()">
+          <mat-icon>exit_to_app</mat-icon>
+          Leave Room
+        </button>
+      </div>
 
-  <div class="connection-status" [class.connected]="connectionState() === 'connected'">
-    <span class="status-dot"></span>
-    <span class="status-text">
+    }
+
+  </div>
+
+  <!-- Connection status pill -->
+  <div class="connection-pill" [class.connection-pill--ok]="connectionState() === 'connected'">
+    <span class="connection-dot"></span>
+    <span class="connection-label">
       @switch (connectionState()) {
         @case ('connected') { Connected }
         @case ('connecting') { Connecting... }
@@ -130,4 +160,5 @@
       }
     </span>
   </div>
+
 </div>

--- a/apps/client/src/app/lobby/lobby/lobby.component.scss
+++ b/apps/client/src/app/lobby/lobby/lobby.component.scss
@@ -172,6 +172,14 @@
 .code-field {
   width: 100%;
   max-width: 210px;
+
+  input {
+    text-transform: uppercase;
+    letter-spacing: 0.5rem;
+    text-align: center;
+    font-size: 1.3rem;
+    font-weight: 700;
+  }
 }
 
 // Buttons
@@ -242,8 +250,7 @@
 
 @keyframes pulse-battle {
   0%, 100% { box-shadow: 0 0 0 0 rgba(230, 57, 70, 0); }
-  50% { box-shadow: 0 0 0 8px rgba(230, 57, 70, 0); }
-  25% { box-shadow: 0 0 0 4px rgba(230, 57, 70, 0.35); }
+  50% { box-shadow: 0 0 0 8px rgba(230, 57, 70, 0.4); }
 }
 
 // Waiting area

--- a/apps/client/src/app/lobby/lobby/lobby.component.scss
+++ b/apps/client/src/app/lobby/lobby/lobby.component.scss
@@ -1,174 +1,424 @@
-.lobby-container {
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 24px 16px;
+.lobby-page {
   height: 100%;
   overflow: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
   box-sizing: border-box;
+  padding: 24px 16px 88px;
 }
 
-.lobby-header {
-  text-align: center;
-  margin-bottom: 32px;
-
-  h1 {
-    font-size: 2.5rem;
-    font-weight: 700;
-    margin: 0 0 8px;
-  }
-
-  p {
-    color: var(--mat-sys-on-surface-variant);
-    font-size: 1.1rem;
-    margin: 0;
-  }
+// Decorative background
+.lobby-bg {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  z-index: 0;
 }
 
-.error-banner {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 12px 16px;
-  margin-bottom: 24px;
-  background: var(--mat-sys-error-container);
-  color: var(--mat-sys-on-error-container);
-  border-radius: 12px;
+.lobby-bg-pokeball {
+  width: 560px;
+  height: 560px;
 }
 
-.lobby-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 24px;
-}
-
-.lobby-card {
-  .card-avatar {
-    background: var(--mat-sys-primary-container);
-    color: var(--mat-sys-on-primary-container);
-    border-radius: 50%;
-    width: 40px;
-    height: 40px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  mat-card-content p {
-    color: var(--mat-sys-on-surface-variant);
-  }
-
-  mat-card-actions {
-    padding: 16px;
-  }
-}
-
-.room-code-field {
+.lobby-content {
+  position: relative;
+  z-index: 1;
   width: 100%;
-}
-
-// Waiting room
-.waiting-room {
-  display: flex;
-  justify-content: center;
-}
-
-.waiting-card {
-  max-width: 450px;
-  width: 100%;
-}
-
-.waiting-content, .ready-content {
+  max-width: 780px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  text-align: center;
-  gap: 16px;
-  padding: 16px 0;
-
-  h2 {
-    margin: 0;
-  }
+  gap: 28px;
 }
 
-.room-code-display {
+// Hero
+.lobby-hero {
+  text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
+  padding-top: 8px;
 }
 
-.code-label {
-  color: var(--mat-sys-on-surface-variant);
+.hero-icon {
+  filter: drop-shadow(0 0 20px rgba(230, 57, 70, 0.5));
+  animation: hero-bob 3s ease-in-out infinite;
+}
+
+@keyframes hero-bob {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-7px); }
+}
+
+.hero-title {
+  font-family: var(--font-game);
+  font-size: clamp(2.6rem, 6vw, 4.2rem);
+  letter-spacing: 5px;
+  margin: 0;
+  line-height: 1;
+  color: var(--color-text);
+}
+
+.hero-subtitle {
+  color: var(--color-text-muted);
+  font-size: 1rem;
+  margin: 0;
+}
+
+// Error
+.alert-error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 8px;
+  color: #fca5a5;
+  width: 100%;
+  box-sizing: border-box;
   font-size: 0.9rem;
 }
 
-.code-box {
+// Lobby actions panel
+.lobby-actions {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.action-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 32px 28px;
+  gap: 14px;
+}
+
+.action-card__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  mat-icon {
+    font-size: 24px;
+    width: 24px;
+    height: 24px;
+  }
+
+  &--create {
+    background: var(--color-primary-dim);
+    color: var(--color-primary);
+    border: 1px solid rgba(230, 57, 70, 0.25);
+  }
+
+  &--join {
+    background: var(--color-player-1-dim);
+    color: var(--color-player-1);
+    border: 1px solid rgba(59, 130, 246, 0.25);
+  }
+}
+
+.action-card__title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--color-text);
+}
+
+.action-card__desc {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin: 0;
+  max-width: 220px;
+  line-height: 1.5;
+}
+
+.actions-divider {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 1px;
+  background: var(--color-border);
+  position: relative;
+  flex-shrink: 0;
+
+  span {
+    position: absolute;
+    background: var(--color-surface);
+    color: var(--color-text-muted);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 1px;
+    padding: 6px 2px;
+  }
+}
+
+.code-field {
+  width: 100%;
+  max-width: 210px;
+}
+
+// Buttons
+.action-btn {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 8px 16px;
-  background: var(--mat-sys-surface-container-high);
-  border: 2px dashed var(--mat-sys-outline-variant);
-  border-radius: 12px;
+  justify-content: center;
+  gap: 7px;
+  padding: 0 22px;
+  height: 42px;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  font-size: 0.88rem;
+  font-weight: 600;
+  font-family: Roboto, sans-serif;
+  transition: all 0.18s ease;
+  text-decoration: none;
+  white-space: nowrap;
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  &--primary {
+    background: var(--color-primary);
+    color: white;
+
+    &:hover:not(:disabled) {
+      background: var(--color-primary-hover);
+    }
+  }
+
+  &--secondary {
+    background: var(--color-surface-elevated);
+    color: var(--color-text);
+    border: 1px solid var(--color-border-strong);
+
+    &:hover:not(:disabled) {
+      background: var(--color-surface-highest);
+      border-color: rgba(59, 130, 246, 0.5);
+      color: var(--color-player-1);
+    }
+  }
+
+  &--battle {
+    background: var(--color-primary);
+    color: white;
+    height: 50px;
+    padding: 0 32px;
+    font-size: 1rem;
+    border-radius: 10px;
+    animation: pulse-battle 2s ease-in-out infinite;
+
+    &:hover {
+      background: var(--color-primary-hover);
+    }
+  }
 }
 
-.code-text {
-  font-size: 2rem;
+@keyframes pulse-battle {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(230, 57, 70, 0); }
+  50% { box-shadow: 0 0 0 8px rgba(230, 57, 70, 0); }
+  25% { box-shadow: 0 0 0 4px rgba(230, 57, 70, 0.35); }
+}
+
+// Waiting area
+.waiting-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  max-width: 420px;
+}
+
+.waiting-card,
+.ready-card {
+  width: 100%;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  padding: 36px 28px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+  box-sizing: border-box;
+}
+
+.waiting-pokeball {
+  animation: pokeball-spin 2s linear infinite;
+  filter: drop-shadow(0 0 10px rgba(230, 57, 70, 0.4));
+}
+
+@keyframes pokeball-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.waiting-title,
+.ready-title {
+  font-size: 1.35rem;
   font-weight: 700;
-  color: var(--mat-sys-primary);
-  letter-spacing: 0.5rem;
-  font-family: monospace;
+  margin: 0;
+  color: var(--color-text);
 }
 
-.waiting-hint {
-  color: var(--mat-sys-on-surface-variant);
-  font-size: 0.95rem;
+.waiting-hint,
+.ready-hint {
+  color: var(--color-text-muted);
+  font-size: 0.88rem;
   margin: 0;
+}
+
+.room-code-block {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--color-surface-elevated);
+  border: 2px solid var(--color-gold);
+  border-radius: 12px;
+  padding: 10px 18px;
+}
+
+.room-code-value {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: var(--color-gold);
+  letter-spacing: 0.55rem;
+}
+
+.copy-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  padding: 4px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s, background 0.15s;
+
+  &:hover {
+    color: var(--color-gold);
+    background: var(--color-gold-dim);
+  }
+}
+
+.player-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: var(--color-primary-dim);
+  border: 1px solid rgba(230, 57, 70, 0.25);
+  border-radius: 20px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-primary);
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
 }
 
 .ready-icon {
-  font-size: 48px;
-  width: 48px;
-  height: 48px;
-  color: var(--mat-sys-primary);
+  mat-icon {
+    font-size: 58px;
+    width: 58px;
+    height: 58px;
+    color: var(--color-success);
+    filter: drop-shadow(0 0 12px rgba(34, 197, 94, 0.5));
+  }
 }
 
-.ready-content p {
-  color: var(--mat-sys-on-surface-variant);
-  margin: 0;
-}
+.leave-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  font-family: Roboto, sans-serif;
+  border-radius: 6px;
+  transition: color 0.15s, background 0.15s;
 
-.start-btn {
-  margin-top: 8px;
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+
+  &:hover {
+    color: var(--color-primary);
+    background: var(--color-primary-dim);
+  }
 }
 
 // Connection status
-.connection-status {
+.connection-pill {
   position: fixed;
   bottom: 16px;
   right: 16px;
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
-  background: var(--mat-sys-surface-container);
+  gap: 7px;
+  padding: 6px 14px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 20px;
-  font-size: 0.85rem;
-  color: var(--mat-sys-on-surface-variant);
-
-  &.connected {
-    .status-dot {
-      background: #4caf50;
-    }
-    .status-text {
-      color: #4caf50;
-    }
-  }
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  z-index: 10;
 }
 
-.status-dot {
-  width: 8px;
-  height: 8px;
+.connection-dot {
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
-  background: var(--mat-sys-outline);
+  background: var(--color-text-muted);
+  flex-shrink: 0;
+  transition: all 0.3s ease;
+}
+
+.connection-pill--ok {
+  .connection-dot {
+    background: var(--color-success);
+    box-shadow: 0 0 6px var(--color-success);
+  }
+
+  .connection-label {
+    color: var(--color-success);
+  }
 }

--- a/apps/client/src/app/lobby/lobby/lobby.component.spec.ts
+++ b/apps/client/src/app/lobby/lobby/lobby.component.spec.ts
@@ -51,7 +51,7 @@ describe('LobbyComponent', () => {
 
   describe('rendering — idle state', () => {
     it('renders Create Room button', () => {
-      expect(fixture.nativeElement.textContent).toContain('Create New Room');
+      expect(fixture.nativeElement.textContent).toContain('Create Room');
     });
 
     it('renders Join Room input', () => {
@@ -61,16 +61,16 @@ describe('LobbyComponent', () => {
 
     it('renders lobby heading', () => {
       const h1 = fixture.nativeElement.querySelector('h1');
-      expect(h1?.textContent).toContain('Pokemon Duel');
+      expect(h1?.textContent).toContain('POKEMON DUEL');
     });
 
     it('renders connection status indicator', () => {
-      const status = fixture.nativeElement.querySelector('.connection-status');
+      const status = fixture.nativeElement.querySelector('.connection-pill');
       expect(status).toBeTruthy();
     });
 
     it('shows Disconnected by default', () => {
-      const statusText = fixture.nativeElement.querySelector('.status-text');
+      const statusText = fixture.nativeElement.querySelector('.connection-label');
       expect(statusText?.textContent?.trim()).toBe('Disconnected');
     });
 
@@ -78,7 +78,7 @@ describe('LobbyComponent', () => {
       mockSignalRService.connectionState.set('connected');
       fixture.detectChanges();
 
-      const statusText = fixture.nativeElement.querySelector('.status-text');
+      const statusText = fixture.nativeElement.querySelector('.connection-label');
       expect(statusText?.textContent?.trim()).toBe('Connected');
     });
   });

--- a/apps/client/src/app/lobby/lobby/lobby.component.ts
+++ b/apps/client/src/app/lobby/lobby/lobby.component.ts
@@ -9,24 +9,20 @@ import { Router } from '@angular/router';
 import { MultiplayerService } from '../../multiplayer/multiplayer.service';
 import { MultiplayerStore } from '../../multiplayer/multiplayer.store';
 import { SignalRService } from '../../multiplayer/signalr.service';
-import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
-import { MatChipsModule } from '@angular/material/chips';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 @Component({
   selector: 'app-lobby',
   standalone: true,
   imports: [
-    MatCardModule,
     MatButtonModule,
     MatInputModule,
     MatFormFieldModule,
     MatIconModule,
-    MatChipsModule,
     MatProgressSpinnerModule,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/client/src/index.html
+++ b/apps/client/src/index.html
@@ -6,7 +6,9 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>

--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -4,7 +4,7 @@ html {
   color-scheme: dark;
   @include mat.theme((
     color: (
-      primary: mat.$violet-palette,
+      primary: mat.$red-palette,
       theme-type: dark,
     ),
     typography: Roboto,
@@ -12,10 +12,36 @@ html {
   ));
 }
 
+:root {
+  --color-bg: #0D1117;
+  --color-surface: #161B22;
+  --color-surface-elevated: #21262D;
+  --color-surface-highest: #30363D;
+  --color-primary: #E63946;
+  --color-primary-hover: #c1121f;
+  --color-primary-dim: rgba(230, 57, 70, 0.13);
+  --color-gold: #F7D716;
+  --color-gold-dim: rgba(247, 215, 22, 0.12);
+  --color-player-1: #3B82F6;
+  --color-player-1-dim: rgba(59, 130, 246, 0.12);
+  --color-player-2: #EF4444;
+  --color-player-2-dim: rgba(239, 68, 68, 0.12);
+  --color-type-water: #38BDF8;
+  --color-type-fire: #FB923C;
+  --color-type-grass: #4ADE80;
+  --color-type-normal: #94A3B8;
+  --color-success: #22C55E;
+  --color-border: rgba(255, 255, 255, 0.08);
+  --color-border-strong: rgba(255, 255, 255, 0.16);
+  --color-text: #E6EDF3;
+  --color-text-muted: #8B949E;
+  --font-game: 'Bebas Neue', 'Impact', system-ui, sans-serif;
+}
+
 body {
   margin: 0;
-  background: var(--mat-sys-surface);
-  color: var(--mat-sys-on-surface);
+  background: var(--color-bg);
+  color: var(--color-text);
   font-family: Roboto, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
Replace generic Angular Material violet theme with an immersive dark
Pokemon-themed design:

- Global: deep space dark palette (#0D1117), Pokemon Red (#E63946) primary,
  electric gold accents, Bebas Neue game font via Google Fonts
- App shell: custom dark nav bar with Pokéball SVG logo and pill navigation links
- Lobby: hero section with animated Pokéball, glassmorphic action cards,
  gold room-code display, spinning Pokéball waiting animation
- Game header (B2 compact): Bebas Neue brand + player-colored turn badge
  centered + action buttons — scales to N players
- Win/defeat overlays: gold Bebas Neue VICTORY, red DEFEAT with dramatic
  shadows and drop-shadow glow effects
- Battle toast: type badges (water/fire/grass/normal) per Pokemon, larger
  dice numbers, auto-dismiss after 3s, click-to-dismiss
- Board canvas: subtle grid texture, updated bench area colors
- Spots: entry spots with red glow, flag spots with gold glow
- Pokemon pieces: type-colored radial gradient backgrounds, larger selected
  gold glow
- Passages: thicker lines with type-specific drop-shadow glow effects
- Multiplayer: add 3s auto-dismiss timer for battle toast (parity with local)

No game logic changes.

https://claude.ai/code/session_0161LdFFb93oK4AUhwt64c6Z