### PR TITLE
feature(board): add constrained force-directed beautify algorithm

### DIFF
--- a/apps/client/src/app/board-editor/board-controls/board-controls.component.html
+++ b/apps/client/src/app/board-editor/board-controls/board-controls.component.html
@@ -197,6 +197,35 @@
     </button>
   </div>
 
+  <!-- Beautify -->
+  <div class="control-group">
+    @if (store.isBeautifying()) {
+      <button
+        class="control-btn control-btn--danger"
+        data-testid="beautify-stop-btn"
+        (click)="stopBeautify()"
+      >
+        ■ Stop
+      </button>
+    } @else {
+      <button
+        class="control-btn control-btn--beautify"
+        data-testid="beautify-btn"
+        (click)="beautify()"
+      >
+        ✦ Beautify
+      </button>
+    }
+    <button
+      class="control-btn"
+      data-testid="beautify-animate-toggle"
+      [class.control-btn--active]="store.beautifyAnimated()"
+      (click)="toggleBeautifyAnimation()"
+    >
+      Animate: {{ store.beautifyAnimated() ? 'ON' : 'OFF' }}
+    </button>
+  </div>
+
   <!-- Validation Status -->
   <div class="control-group">
     <div

--- a/apps/client/src/app/board-editor/board-controls/board-controls.component.scss
+++ b/apps/client/src/app/board-editor/board-controls/board-controls.component.scss
@@ -142,6 +142,17 @@
     border-color: var(--mat-sys-error);
     color: var(--mat-sys-on-error-container);
   }
+
+  &--beautify {
+    border-color: #7c4dff;
+    color: #7c4dff;
+    font-weight: 600;
+
+    &:hover {
+      background: color-mix(in srgb, #7c4dff 12%, transparent);
+      border-color: #7c4dff;
+    }
+  }
 }
 
 .import-btn {

--- a/apps/client/src/app/board-editor/board-controls/board-controls.component.ts
+++ b/apps/client/src/app/board-editor/board-controls/board-controls.component.ts
@@ -97,6 +97,22 @@ export class BoardControlsComponent {
   }
 
   // ==========================================================================
+  // Beautify
+  // ==========================================================================
+
+  protected beautify(): void {
+    this.store.beautify();
+  }
+
+  protected stopBeautify(): void {
+    this.store.stopBeautify();
+  }
+
+  protected toggleBeautifyAnimation(): void {
+    this.store.toggleBeautifyAnimation();
+  }
+
+  // ==========================================================================
   // Persistence
   // ==========================================================================
 

--- a/libs/board/src/index.ts
+++ b/libs/board/src/index.ts
@@ -13,5 +13,6 @@ export * from './lib/services/board.service';
 
 // Utils
 export * from './lib/utils/grid.utils';
+export * from './lib/utils/beautify.utils';
 export * from './lib/store/battle.utils';
 export * from './lib/store/movement.utils';

--- a/libs/board/src/lib/store/board.store.ts
+++ b/libs/board/src/lib/store/board.store.ts
@@ -12,8 +12,7 @@ import { Spot, Passage, EditingMode, SpotType, PassageType } from '../models/boa
 import {
   BeautifyOptions,
   initBeautify,
-  runFRStep,
-  coolTemperature,
+  computeStep,
   applyPositions,
 } from '../utils/beautify.utils';
 import { snapToGrid } from '../utils/grid.utils';
@@ -315,35 +314,32 @@ export const BoardStore = signalStore(
       /**
        * Beautify the current board.
        *
-       * When `beautifyAnimated` is true, runs the algorithm step-by-step using
-       * requestAnimationFrame so the board visually morphs into the new layout.
-       * When false, applies all iterations instantly in a single synchronous pass.
+       * Layout is computed synchronously (BFS y-layers + x-only F-R), then
+       * either applied instantly or animated as a smooth eased lerp from each
+       * spot's current position to its computed target.
        *
-       * Entry spots are pre-positioned near their bench edges before the
-       * force-directed algorithm begins. Flag spots are pinned in place.
+       * Entry spots → repositioned to their bench edge, evenly spread in x.
+       * Flag spots  → repositioned to center of bench, same y as their entries.
+       * Normal spots → BFS y-layer + x-optimised F-R.
        */
       beautify(options?: BeautifyOptions): void {
-        stopBeautify(); // Cancel any in-progress animation
+        stopBeautify();
 
         const spots = store.spotEntities();
         const passages = store.passageEntities();
         if (spots.length === 0) return;
 
         const board = { id: '', name: '', spots, passages };
-        const gridCellSize = 50;
-        const opts: BeautifyOptions = {
+        const state = initBeautify(board, {
           gridSnap: store.gridSnapEnabled(),
-          gridCellSize,
+          gridCellSize: 50,
           ...options,
-        };
+        });
 
-        const state = initBeautify(board, opts);
-        const { iterations, stepsPerFrame } = state.opts;
-
-        // Apply pre-positioned entry spots immediately so they "snap" to the
-        // bench edge before the animation begins.
+        // Apply anchor spots (entry + flag) immediately in both paths so they
+        // snap to their bench positions before the animation begins.
         for (const id of state.fixed) {
-          const p = state.positions.get(id)!;
+          const p = state.targetPositions.get(id)!;
           patchState(
             store,
             updateEntity(
@@ -354,14 +350,10 @@ export const BoardStore = signalStore(
         }
 
         if (!store.beautifyAnimated()) {
-          // --- Instant path ---
-          for (let iter = 0; iter < iterations; iter++) {
-            runFRStep(spots, passages, state);
-            coolTemperature(state, iter);
-          }
+          // --- Instant path: apply target positions directly ---
           const result = applyPositions(board, state);
           for (const spot of result.spots) {
-            if (state.fixed.has(spot.id)) continue; // already applied above
+            if (state.fixed.has(spot.id)) continue;
             patchState(
               store,
               updateEntity(
@@ -373,22 +365,16 @@ export const BoardStore = signalStore(
           return;
         }
 
-        // --- Animated path ---
+        // --- Animated path: lerp from start → target over animationFrames ---
         patchState(store, { isBeautifying: true });
-        let iter = 0;
 
         function frame(): void {
-          const batchEnd = Math.min(iter + stepsPerFrame, iterations);
-          while (iter < batchEnd) {
-            runFRStep(spots, passages, state);
-            coolTemperature(state, iter);
-            iter++;
-          }
+          const done = computeStep(state);
 
-          // Push current positions for all free spots into the store
+          // Push interpolated positions to the store each frame
           for (const spot of spots) {
             if (state.fixed.has(spot.id)) continue;
-            const p = state.positions.get(spot.id)!;
+            const p = state.currentPositions.get(spot.id)!;
             patchState(
               store,
               updateEntity(
@@ -398,30 +384,26 @@ export const BoardStore = signalStore(
             );
           }
 
-          if (iter < iterations) {
+          if (!done) {
             animFrameId = requestAnimationFrame(frame);
             return;
           }
 
-          // Final frame: apply grid snap if enabled
-          if (state.opts.gridSnap) {
-            for (const spot of spots) {
-              if (state.fixed.has(spot.id)) continue;
-              const p = state.positions.get(spot.id)!;
-              patchState(
-                store,
-                updateEntity(
-                  {
-                    id: spot.id,
-                    changes: {
-                      x: snapToGrid(Math.round(p.x), state.opts.gridCellSize),
-                      y: snapToGrid(Math.round(p.y), state.opts.gridCellSize),
-                    },
-                  },
-                  { collection: 'spot' },
-                ),
-              );
-            }
+          // Final frame: write exact target positions (removes rounding drift)
+          // and apply grid snap if enabled.
+          for (const spot of spots) {
+            if (state.fixed.has(spot.id)) continue;
+            const p = state.targetPositions.get(spot.id)!;
+            const x = state.opts.gridSnap
+              ? snapToGrid(Math.round(p.x), state.opts.gridCellSize)
+              : Math.round(p.x);
+            const y = state.opts.gridSnap
+              ? snapToGrid(Math.round(p.y), state.opts.gridCellSize)
+              : Math.round(p.y);
+            patchState(
+              store,
+              updateEntity({ id: spot.id, changes: { x, y } }, { collection: 'spot' }),
+            );
           }
 
           animFrameId = null;

--- a/libs/board/src/lib/store/board.store.ts
+++ b/libs/board/src/lib/store/board.store.ts
@@ -9,6 +9,14 @@ import {
   removeAllEntities,
 } from '@ngrx/signals/entities';
 import { Spot, Passage, EditingMode, SpotType, PassageType } from '../models/board.models';
+import {
+  BeautifyOptions,
+  initBeautify,
+  runFRStep,
+  coolTemperature,
+  applyPositions,
+} from '../utils/beautify.utils';
+import { snapToGrid } from '../utils/grid.utils';
 
 // ============================================================================
 // State Types
@@ -26,6 +34,10 @@ type BoardUIState = {
   newSpotPlayerId: number;
   /** Passage type to use when creating new passages */
   newPassageType: PassageType;
+  /** True while an animated beautify pass is running */
+  isBeautifying: boolean;
+  /** Whether beautify should animate step-by-step (vs instant) */
+  beautifyAnimated: boolean;
 };
 
 const initialUIState: BoardUIState = {
@@ -37,6 +49,8 @@ const initialUIState: BoardUIState = {
   newSpotType: 'normal',
   newSpotPlayerId: 1,
   newPassageType: 'normal',
+  isBeautifying: false,
+  beautifyAnimated: true,
 };
 
 // ============================================================================
@@ -154,131 +168,268 @@ export const BoardStore = signalStore(
   ),
 
   // Methods
-  withMethods((store) => ({
-    // Spot operations
-    addSpot(spot: Spot): void {
-      patchState(store, addEntity(spot, { collection: 'spot' }));
-    },
+  withMethods((store) => {
+    // Animation frame ID lives outside of state so it never triggers re-renders
+    let animFrameId: number | null = null;
 
-    updateSpot(id: string, changes: Partial<Spot>): void {
-      patchState(store, updateEntity({ id, changes }, { collection: 'spot' }));
-    },
+    function stopBeautify(): void {
+      if (animFrameId !== null) {
+        cancelAnimationFrame(animFrameId);
+        animFrameId = null;
+      }
+      patchState(store, { isBeautifying: false });
+    }
 
-    deleteSpot(id: string): void {
-      // Remove connected passages first
-      const passagesToRemove = store
-        .passageEntities()
-        .filter((p) => p.fromSpotId === id || p.toSpotId === id)
-        .map((p) => p.id);
+    return {
+      // Spot operations
+      addSpot(spot: Spot): void {
+        patchState(store, addEntity(spot, { collection: 'spot' }));
+      },
 
-      patchState(
-        store,
-        removeEntities(passagesToRemove, { collection: 'passage' }),
-        removeEntity(id, { collection: 'spot' }),
-        // Clear selection if this spot was selected
-        store.selectedSpotId() === id ? { selectedSpotId: null } : {},
-      );
-    },
+      updateSpot(id: string, changes: Partial<Spot>): void {
+        patchState(store, updateEntity({ id, changes }, { collection: 'spot' }));
+      },
 
-    selectSpot(id: string | null): void {
-      patchState(store, {
-        selectedSpotId: id,
-        selectedPassageId: null, // Clear passage selection
-      });
-    },
+      deleteSpot(id: string): void {
+        // Remove connected passages first
+        const passagesToRemove = store
+          .passageEntities()
+          .filter((p) => p.fromSpotId === id || p.toSpotId === id)
+          .map((p) => p.id);
 
-    // Passage operations
-    addPassage(passage: Passage): void {
-      const spots = store.spotEntities();
-      const passages = store.passageEntities();
+        patchState(
+          store,
+          removeEntities(passagesToRemove, { collection: 'passage' }),
+          removeEntity(id, { collection: 'spot' }),
+          store.selectedSpotId() === id ? { selectedSpotId: null } : {},
+        );
+      },
 
-      // Validate both spots exist
-      const fromExists = spots.some((s) => s.id === passage.fromSpotId);
-      const toExists = spots.some((s) => s.id === passage.toSpotId);
-      if (!fromExists || !toExists) return;
+      selectSpot(id: string | null): void {
+        patchState(store, {
+          selectedSpotId: id,
+          selectedPassageId: null,
+        });
+      },
 
-      // Check for duplicate (in either direction)
-      if (passageExists(passages, passage.fromSpotId, passage.toSpotId)) return;
+      // Passage operations
+      addPassage(passage: Passage): void {
+        const spots = store.spotEntities();
+        const passages = store.passageEntities();
 
-      patchState(store, addEntity(passage, { collection: 'passage' }));
-    },
+        const fromExists = spots.some((s) => s.id === passage.fromSpotId);
+        const toExists = spots.some((s) => s.id === passage.toSpotId);
+        if (!fromExists || !toExists) return;
 
-    updatePassage(id: string, changes: Partial<Passage>): void {
-      patchState(store, updateEntity({ id, changes }, { collection: 'passage' }));
-    },
+        if (passageExists(passages, passage.fromSpotId, passage.toSpotId)) return;
 
-    deletePassage(id: string): void {
-      patchState(
-        store,
-        removeEntity(id, { collection: 'passage' }),
-        // Clear selection if this passage was selected
-        store.selectedPassageId() === id ? { selectedPassageId: null } : {},
-      );
-    },
+        patchState(store, addEntity(passage, { collection: 'passage' }));
+      },
 
-    selectPassage(id: string | null): void {
-      patchState(store, {
-        selectedPassageId: id,
-        selectedSpotId: null, // Clear spot selection
-      });
-    },
+      updatePassage(id: string, changes: Partial<Passage>): void {
+        patchState(store, updateEntity({ id, changes }, { collection: 'passage' }));
+      },
 
-    // Passage creation helpers
-    setPassageSource(id: string | null): void {
-      patchState(store, { passageSourceSpotId: id });
-    },
+      deletePassage(id: string): void {
+        patchState(
+          store,
+          removeEntity(id, { collection: 'passage' }),
+          store.selectedPassageId() === id ? { selectedPassageId: null } : {},
+        );
+      },
 
-    // Get passages for a specific spot
-    passagesForSpot(spotId: string): Passage[] {
-      return store
-        .passageEntities()
-        .filter((p) => p.fromSpotId === spotId || p.toSpotId === spotId);
-    },
+      selectPassage(id: string | null): void {
+        patchState(store, {
+          selectedPassageId: id,
+          selectedSpotId: null,
+        });
+      },
 
-    // Check if a spot has any connections
-    isSpotConnected(spotId: string): boolean {
-      const spots = store.spotEntities();
-      const passages = store.passageEntities();
+      // Passage creation helpers
+      setPassageSource(id: string | null): void {
+        patchState(store, { passageSourceSpotId: id });
+      },
 
-      // Single spot is always "connected"
-      if (spots.length === 1) return true;
+      // Get passages for a specific spot
+      passagesForSpot(spotId: string): Passage[] {
+        return store
+          .passageEntities()
+          .filter((p) => p.fromSpotId === spotId || p.toSpotId === spotId);
+      },
 
-      // Check if spot has any passages
-      return passages.some((p) => p.fromSpotId === spotId || p.toSpotId === spotId);
-    },
+      // Check if a spot has any connections
+      isSpotConnected(spotId: string): boolean {
+        const spots = store.spotEntities();
+        const passages = store.passageEntities();
 
-    // UI state
-    setEditingMode(mode: EditingMode): void {
-      patchState(store, {
-        editingMode: mode,
-        passageSourceSpotId: null, // Clear passage source when changing modes
-      });
-    },
+        if (spots.length === 1) return true;
 
-    toggleGridSnap(): void {
-      patchState(store, { gridSnapEnabled: !store.gridSnapEnabled() });
-    },
+        return passages.some((p) => p.fromSpotId === spotId || p.toSpotId === spotId);
+      },
 
-    setNewSpotType(type: SpotType): void {
-      patchState(store, { newSpotType: type });
-    },
+      // UI state
+      setEditingMode(mode: EditingMode): void {
+        patchState(store, {
+          editingMode: mode,
+          passageSourceSpotId: null,
+        });
+      },
 
-    setNewSpotPlayerId(playerId: number): void {
-      patchState(store, { newSpotPlayerId: playerId });
-    },
+      toggleGridSnap(): void {
+        patchState(store, { gridSnapEnabled: !store.gridSnapEnabled() });
+      },
 
-    setNewPassageType(type: PassageType): void {
-      patchState(store, { newPassageType: type });
-    },
+      setNewSpotType(type: SpotType): void {
+        patchState(store, { newSpotType: type });
+      },
 
-    // Reset
-    reset(): void {
-      patchState(
-        store,
-        removeAllEntities({ collection: 'spot' }),
-        removeAllEntities({ collection: 'passage' }),
-        initialUIState,
-      );
-    },
-  })),
+      setNewSpotPlayerId(playerId: number): void {
+        patchState(store, { newSpotPlayerId: playerId });
+      },
+
+      setNewPassageType(type: PassageType): void {
+        patchState(store, { newPassageType: type });
+      },
+
+      // Reset
+      reset(): void {
+        stopBeautify();
+        patchState(
+          store,
+          removeAllEntities({ collection: 'spot' }),
+          removeAllEntities({ collection: 'passage' }),
+          initialUIState,
+        );
+      },
+
+      // ======================================================================
+      // Beautify
+      // ======================================================================
+
+      stopBeautify,
+
+      toggleBeautifyAnimation(): void {
+        patchState(store, { beautifyAnimated: !store.beautifyAnimated() });
+      },
+
+      /**
+       * Beautify the current board.
+       *
+       * When `beautifyAnimated` is true, runs the algorithm step-by-step using
+       * requestAnimationFrame so the board visually morphs into the new layout.
+       * When false, applies all iterations instantly in a single synchronous pass.
+       *
+       * Entry spots are pre-positioned near their bench edges before the
+       * force-directed algorithm begins. Flag spots are pinned in place.
+       */
+      beautify(options?: BeautifyOptions): void {
+        stopBeautify(); // Cancel any in-progress animation
+
+        const spots = store.spotEntities();
+        const passages = store.passageEntities();
+        if (spots.length === 0) return;
+
+        const board = { id: '', name: '', spots, passages };
+        const gridCellSize = 50;
+        const opts: BeautifyOptions = {
+          gridSnap: store.gridSnapEnabled(),
+          gridCellSize,
+          ...options,
+        };
+
+        const state = initBeautify(board, opts);
+        const { iterations, stepsPerFrame } = state.opts;
+
+        // Apply pre-positioned entry spots immediately so they "snap" to the
+        // bench edge before the animation begins.
+        for (const id of state.fixed) {
+          const p = state.positions.get(id)!;
+          patchState(
+            store,
+            updateEntity(
+              { id, changes: { x: Math.round(p.x), y: Math.round(p.y) } },
+              { collection: 'spot' },
+            ),
+          );
+        }
+
+        if (!store.beautifyAnimated()) {
+          // --- Instant path ---
+          for (let iter = 0; iter < iterations; iter++) {
+            runFRStep(spots, passages, state);
+            coolTemperature(state, iter);
+          }
+          const result = applyPositions(board, state);
+          for (const spot of result.spots) {
+            if (state.fixed.has(spot.id)) continue; // already applied above
+            patchState(
+              store,
+              updateEntity(
+                { id: spot.id, changes: { x: spot.x, y: spot.y } },
+                { collection: 'spot' },
+              ),
+            );
+          }
+          return;
+        }
+
+        // --- Animated path ---
+        patchState(store, { isBeautifying: true });
+        let iter = 0;
+
+        function frame(): void {
+          const batchEnd = Math.min(iter + stepsPerFrame, iterations);
+          while (iter < batchEnd) {
+            runFRStep(spots, passages, state);
+            coolTemperature(state, iter);
+            iter++;
+          }
+
+          // Push current positions for all free spots into the store
+          for (const spot of spots) {
+            if (state.fixed.has(spot.id)) continue;
+            const p = state.positions.get(spot.id)!;
+            patchState(
+              store,
+              updateEntity(
+                { id: spot.id, changes: { x: Math.round(p.x), y: Math.round(p.y) } },
+                { collection: 'spot' },
+              ),
+            );
+          }
+
+          if (iter < iterations) {
+            animFrameId = requestAnimationFrame(frame);
+            return;
+          }
+
+          // Final frame: apply grid snap if enabled
+          if (state.opts.gridSnap) {
+            for (const spot of spots) {
+              if (state.fixed.has(spot.id)) continue;
+              const p = state.positions.get(spot.id)!;
+              patchState(
+                store,
+                updateEntity(
+                  {
+                    id: spot.id,
+                    changes: {
+                      x: snapToGrid(Math.round(p.x), state.opts.gridCellSize),
+                      y: snapToGrid(Math.round(p.y), state.opts.gridCellSize),
+                    },
+                  },
+                  { collection: 'spot' },
+                ),
+              );
+            }
+          }
+
+          animFrameId = null;
+          patchState(store, { isBeautifying: false });
+        }
+
+        animFrameId = requestAnimationFrame(frame);
+      },
+    };
+  }),
 );

--- a/libs/board/src/lib/utils/beautify.utils.spec.ts
+++ b/libs/board/src/lib/utils/beautify.utils.spec.ts
@@ -3,8 +3,7 @@ import { Board, Spot, Passage } from '../models/board.models';
 import {
   beautifyBoard,
   initBeautify,
-  runFRStep,
-  coolTemperature,
+  computeStep,
   applyPositions,
   BeautifyOptions,
 } from './beautify.utils';
@@ -25,10 +24,7 @@ function makeSpot(
     name: '',
     x,
     y,
-    metadata:
-      type === 'normal'
-        ? { type: 'normal' }
-        : { type, playerId },
+    metadata: type === 'normal' ? { type: 'normal' } : { type, playerId },
   };
 }
 
@@ -36,39 +32,51 @@ function makePassage(id: string, from: string, to: string): Passage {
   return { id, fromSpotId: from, toSpotId: to, passageType: 'normal' };
 }
 
-/** A minimal 2-player board: 2 entries, 2 flags, 4 normal spots in a chain */
-function makeSimpleBoard(): Board {
+/**
+ * Standard 2-player board: 2 entries + 1 flag per player, 4 normal spots.
+ * P1 (bottom): entries at y≈480, flag at y≈480
+ * P2 (top):    entries at y≈20,  flag at y≈20
+ */
+function makeBoard(): Board {
   return {
     id: 'test',
     name: 'Test',
     spots: [
-      makeSpot('e1', 100, 480, 'entry', 1), // P1 entry — bottom-ish
-      makeSpot('e2', 900, 480, 'entry', 1), // P1 entry — bottom-ish
-      makeSpot('f1', 500, 480, 'flag', 1),  // P1 flag
-      makeSpot('e3', 100,  20, 'entry', 2), // P2 entry — top-ish
-      makeSpot('e4', 900,  20, 'entry', 2), // P2 entry — top-ish
-      makeSpot('f2', 500,  20, 'flag', 2),  // P2 flag
-      makeSpot('n1', 110, 100),              // normal — clustered
-      makeSpot('n2', 120, 110),              // normal — clustered
-      makeSpot('n3', 130, 390),              // normal — clustered
-      makeSpot('n4', 140, 400),              // normal — clustered
+      makeSpot('e1a', 200, 480, 'entry', 1),
+      makeSpot('e1b', 800, 480, 'entry', 1),
+      makeSpot('f1',  500, 480, 'flag',  1),
+      makeSpot('e2a', 200,  20, 'entry', 2),
+      makeSpot('e2b', 800,  20, 'entry', 2),
+      makeSpot('f2',  500,  20, 'flag',  2),
+      makeSpot('n1',  110, 100),
+      makeSpot('n2',  120, 110),
+      makeSpot('n3',  130, 390),
+      makeSpot('n4',  140, 400),
     ],
     passages: [
-      makePassage('p1', 'e1', 'n1'),
-      makePassage('p2', 'n1', 'n2'),
-      makePassage('p3', 'n2', 'e3'),
-      makePassage('p4', 'e2', 'n3'),
-      makePassage('p5', 'n3', 'n4'),
-      makePassage('p6', 'n4', 'e4'),
-      makePassage('p7', 'n1', 'n3'),
+      makePassage('p1', 'e1a', 'n3'),
+      makePassage('p2', 'n3',  'n4'),
+      makePassage('p3', 'n4',  'e1b'),
+      makePassage('p4', 'e2a', 'n1'),
+      makePassage('p5', 'n1',  'n2'),
+      makePassage('p6', 'n2',  'e2b'),
+      makePassage('p7', 'n3',  'n1'),
     ],
   };
 }
 
-const OPTS: BeautifyOptions = { iterations: 50, padding: 50, width: 1000, height: 500 };
+const OPTS: BeautifyOptions = {
+  frIterations: 50,
+  animationFrames: 10,
+  padding: 50,
+  width: 1000,
+  height: 500,
+  benchMinX: 200,
+  benchMaxX: 800,
+};
 
 // ============================================================================
-// beautifyBoard — full pipeline
+// beautifyBoard — full instant pipeline
 // ============================================================================
 
 describe('beautifyBoard', () => {
@@ -78,28 +86,30 @@ describe('beautifyBoard', () => {
   });
 
   it('does not mutate the original board', () => {
-    const board = makeSimpleBoard();
-    const originalPositions = board.spots.map((s) => ({ id: s.id, x: s.x, y: s.y }));
+    const board = makeBoard();
+    const snap = board.spots.map((s) => ({ id: s.id, x: s.x, y: s.y }));
     beautifyBoard(board, OPTS);
     board.spots.forEach((s, i) => {
-      expect(s.x).toBe(originalPositions[i].x);
-      expect(s.y).toBe(originalPositions[i].y);
+      expect(s.x).toBe(snap[i].x);
+      expect(s.y).toBe(snap[i].y);
     });
   });
 
   it('preserves passages (topology unchanged)', () => {
-    const board = makeSimpleBoard();
-    const result = beautifyBoard(board, OPTS);
-    expect(result.passages).toEqual(board.passages);
+    const board = makeBoard();
+    expect(beautifyBoard(board, OPTS).passages).toEqual(board.passages);
   });
 
-  it('keeps all free (normal) spots within [padding, width-padding] × [padding, height-padding]', () => {
+  it('returns the correct number of spots', () => {
+    const board = makeBoard();
+    expect(beautifyBoard(board, OPTS).spots).toHaveLength(board.spots.length);
+  });
+
+  it('keeps free spots within board bounds', () => {
     const { padding, width, height } = OPTS as Required<BeautifyOptions>;
-    const board = makeSimpleBoard();
+    const board = makeBoard();
     const state = initBeautify(board, OPTS);
     const result = beautifyBoard(board, OPTS);
-    // Fixed spots (entry/flag) keep their pre-positioned or current coordinates
-    // and are not subject to the boundary clamp.  Only free spots are constrained.
     for (const spot of result.spots) {
       if (state.fixed.has(spot.id)) continue;
       expect(spot.x).toBeGreaterThanOrEqual(padding);
@@ -108,159 +118,185 @@ describe('beautifyBoard', () => {
       expect(spot.y).toBeLessThanOrEqual(height - padding);
     }
   });
-
-  it('returns the correct number of spots', () => {
-    const board = makeSimpleBoard();
-    const result = beautifyBoard(board, OPTS);
-    expect(result.spots).toHaveLength(board.spots.length);
-  });
 });
 
 // ============================================================================
-// initBeautify — entry spot pre-positioning
+// Phase 0: Entry spot positioning
 // ============================================================================
 
-describe('initBeautify — entry spot pre-positioning', () => {
-  it('moves P1 entry spots to the bottom edge (y = height - padding)', () => {
+describe('entry spot positioning', () => {
+  it('places P1 entry spots at the bottom edge (y = height - padding)', () => {
     const { padding, height } = OPTS as Required<BeautifyOptions>;
-    const state = initBeautify(makeSimpleBoard(), OPTS);
-    const p1Entries = makeSimpleBoard().spots.filter(
-      (s) => s.metadata.type === 'entry' && 'playerId' in s.metadata && s.metadata.playerId === 1,
-    );
-    for (const spot of p1Entries) {
-      const pos = state.positions.get(spot.id)!;
-      expect(pos.y).toBe(height! - padding!);
+    const state = initBeautify(makeBoard(), OPTS);
+    const p1EntryIds = makeBoard().spots
+      .filter((s) => s.metadata.type === 'entry' && 'playerId' in s.metadata && s.metadata.playerId === 1)
+      .map((s) => s.id);
+    for (const id of p1EntryIds) {
+      expect(state.targetPositions.get(id)!.y).toBe(height - padding);
     }
   });
 
-  it('moves P2 entry spots to the top edge (y = padding)', () => {
+  it('places P2 entry spots at the top edge (y = padding)', () => {
     const { padding } = OPTS as Required<BeautifyOptions>;
-    const state = initBeautify(makeSimpleBoard(), OPTS);
-    const p2Entries = makeSimpleBoard().spots.filter(
-      (s) => s.metadata.type === 'entry' && 'playerId' in s.metadata && s.metadata.playerId === 2,
-    );
-    for (const spot of p2Entries) {
-      const pos = state.positions.get(spot.id)!;
-      expect(pos.y).toBe(padding!);
+    const state = initBeautify(makeBoard(), OPTS);
+    const p2EntryIds = makeBoard().spots
+      .filter((s) => s.metadata.type === 'entry' && 'playerId' in s.metadata && s.metadata.playerId === 2)
+      .map((s) => s.id);
+    for (const id of p2EntryIds) {
+      expect(state.targetPositions.get(id)!.y).toBe(padding);
     }
   });
 
-  it('distributes multiple entry spots evenly across x', () => {
-    const { padding, width } = OPTS as Required<BeautifyOptions>;
-    const state = initBeautify(makeSimpleBoard(), OPTS);
-    // P1 has 2 entry spots — should be at x=padding and x=width-padding
-    const p1Entries = makeSimpleBoard()
-      .spots.filter(
-        (s) => s.metadata.type === 'entry' && 'playerId' in s.metadata && s.metadata.playerId === 1,
-      )
-      .sort((a, b) => a.x - b.x);
-
-    const xs = p1Entries.map((s) => state.positions.get(s.id)!.x);
-    expect(Math.min(...xs)).toBeCloseTo(padding!, 0);
-    expect(Math.max(...xs)).toBeCloseTo(width! - padding!, 0);
+  it('distributes P1 entry spots within [benchMinX, benchMaxX]', () => {
+    const { benchMinX, benchMaxX } = OPTS as Required<BeautifyOptions>;
+    const state = initBeautify(makeBoard(), OPTS);
+    const p1EntryIds = makeBoard().spots
+      .filter((s) => s.metadata.type === 'entry' && 'playerId' in s.metadata && s.metadata.playerId === 1)
+      .map((s) => s.id);
+    const xs = p1EntryIds.map((id) => state.targetPositions.get(id)!.x);
+    expect(Math.min(...xs)).toBeCloseTo(benchMinX!, 0);
+    expect(Math.max(...xs)).toBeCloseTo(benchMaxX!, 0);
   });
 
   it('pins entry spots in the fixed set', () => {
-    const board = makeSimpleBoard();
-    const state = initBeautify(board, OPTS);
-    const entryIds = board.spots
-      .filter((s) => s.metadata.type === 'entry')
-      .map((s) => s.id);
-    for (const id of entryIds) {
-      expect(state.fixed.has(id)).toBe(true);
+    const state = initBeautify(makeBoard(), OPTS);
+    for (const spot of makeBoard().spots.filter((s) => s.metadata.type === 'entry')) {
+      expect(state.fixed.has(spot.id)).toBe(true);
     }
+  });
+});
+
+// ============================================================================
+// Phase 0: Flag spot positioning
+// ============================================================================
+
+describe('flag spot positioning', () => {
+  it('places P1 flag at center x of bench', () => {
+    const { benchMinX, benchMaxX } = OPTS as Required<BeautifyOptions>;
+    const centerX = (benchMinX! + benchMaxX!) / 2;
+    const state = initBeautify(makeBoard(), OPTS);
+    expect(state.targetPositions.get('f1')!.x).toBeCloseTo(centerX, 0);
+  });
+
+  it('places P2 flag at center x of bench', () => {
+    const { benchMinX, benchMaxX } = OPTS as Required<BeautifyOptions>;
+    const centerX = (benchMinX! + benchMaxX!) / 2;
+    const state = initBeautify(makeBoard(), OPTS);
+    expect(state.targetPositions.get('f2')!.x).toBeCloseTo(centerX, 0);
+  });
+
+  it('places P1 flag at same y as P1 entry spots', () => {
+    const { padding, height } = OPTS as Required<BeautifyOptions>;
+    const state = initBeautify(makeBoard(), OPTS);
+    expect(state.targetPositions.get('f1')!.y).toBe(height - padding);
+  });
+
+  it('places P2 flag at same y as P2 entry spots', () => {
+    const { padding } = OPTS as Required<BeautifyOptions>;
+    const state = initBeautify(makeBoard(), OPTS);
+    expect(state.targetPositions.get('f2')!.y).toBe(padding);
   });
 
   it('pins flag spots in the fixed set', () => {
-    const board = makeSimpleBoard();
-    const state = initBeautify(board, OPTS);
-    const flagIds = board.spots.filter((s) => s.metadata.type === 'flag').map((s) => s.id);
-    for (const id of flagIds) {
-      expect(state.fixed.has(id)).toBe(true);
-    }
+    const state = initBeautify(makeBoard(), OPTS);
+    expect(state.fixed.has('f1')).toBe(true);
+    expect(state.fixed.has('f2')).toBe(true);
+  });
+});
+
+// ============================================================================
+// Phase 1: BFS y-assignment — bottom-side spots stay below middle
+// ============================================================================
+
+describe('BFS y-assignment', () => {
+  it('places spots closer to P1 entries below vertical center', () => {
+    const { height } = OPTS as Required<BeautifyOptions>;
+    const state = initBeautify(makeBoard(), OPTS);
+    // n3 and n4 are only 1 hop from P1 entries → should be in lower half
+    const n3y = state.targetPositions.get('n3')!.y;
+    const n4y = state.targetPositions.get('n4')!.y;
+    expect(n3y).toBeGreaterThan(height / 2);
+    expect(n4y).toBeGreaterThan(height / 2);
+  });
+
+  it('places spots closer to P2 entries above vertical center', () => {
+    const { height } = OPTS as Required<BeautifyOptions>;
+    const state = initBeautify(makeBoard(), OPTS);
+    // n1 and n2 are only 1 hop from P2 entries → should be in upper half
+    const n1y = state.targetPositions.get('n1')!.y;
+    const n2y = state.targetPositions.get('n2')!.y;
+    expect(n1y).toBeLessThan(height / 2);
+    expect(n2y).toBeLessThan(height / 2);
   });
 
   it('does not pin normal spots', () => {
-    const board = makeSimpleBoard();
-    const state = initBeautify(board, OPTS);
-    const normalIds = board.spots.filter((s) => s.metadata.type === 'normal').map((s) => s.id);
-    for (const id of normalIds) {
-      expect(state.fixed.has(id)).toBe(false);
+    const state = initBeautify(makeBoard(), OPTS);
+    for (const spot of makeBoard().spots.filter((s) => s.metadata.type === 'normal')) {
+      expect(state.fixed.has(spot.id)).toBe(false);
     }
   });
 });
 
 // ============================================================================
-// runFRStep — positions evolve, fixed spots stay put
+// computeStep — lerp animation
 // ============================================================================
 
-describe('runFRStep', () => {
+describe('computeStep', () => {
+  it('moves currentPositions toward targetPositions', () => {
+    const board = makeBoard();
+    const state = initBeautify(board, OPTS);
+    const freeId = board.spots.find((s) => s.metadata.type === 'normal')!.id;
+
+    const before = { ...state.currentPositions.get(freeId)! };
+    computeStep(state);
+    const after = state.currentPositions.get(freeId)!;
+
+    const target = state.targetPositions.get(freeId)!;
+    const start  = state.startPositions.get(freeId)!;
+
+    if (start.x !== target.x || start.y !== target.y) {
+      // Position should have moved closer to target
+      const distBefore = Math.abs(before.x - target.x) + Math.abs(before.y - target.y);
+      const distAfter  = Math.abs(after.x  - target.x) + Math.abs(after.y  - target.y);
+      expect(distAfter).toBeLessThanOrEqual(distBefore);
+    }
+  });
+
   it('does not move fixed spots', () => {
-    const board = makeSimpleBoard();
+    const board = makeBoard();
     const state = initBeautify(board, OPTS);
-
-    const before = new Map<string, { x: number; y: number }>();
-    for (const [id, pos] of state.positions) {
-      before.set(id, { ...pos });
-    }
-
-    runFRStep(board.spots, board.passages, state);
-
-    for (const id of state.fixed) {
-      expect(state.positions.get(id)).toEqual(before.get(id));
-    }
+    const fixedId = [...state.fixed][0];
+    const before = { ...state.currentPositions.get(fixedId)! };
+    computeStep(state);
+    // fixed spots are never written to currentPositions by computeStep
+    expect(state.currentPositions.get(fixedId)).toEqual(before);
   });
 
-  it('moves at least one free spot when spots are clustered', () => {
-    const board = makeSimpleBoard();
-    const state = initBeautify(board, OPTS);
-    const freeIds = board.spots
-      .filter((s) => !state.fixed.has(s.id))
-      .map((s) => s.id);
+  it('returns true when totalSteps is reached', () => {
+    const state = initBeautify(makeBoard(), { ...OPTS, animationFrames: 3 });
+    expect(computeStep(state)).toBe(false);
+    expect(computeStep(state)).toBe(false);
+    expect(computeStep(state)).toBe(true);
+  });
 
-    const before = freeIds.map((id) => ({ ...state.positions.get(id)! }));
-    runFRStep(board.spots, board.passages, state);
-    const after = freeIds.map((id) => ({ ...state.positions.get(id)! }));
-
-    const anyMoved = freeIds.some((_, i) => {
-      return before[i].x !== after[i].x || before[i].y !== after[i].y;
-    });
-    expect(anyMoved).toBe(true);
+  it('increments step each call', () => {
+    const state = initBeautify(makeBoard(), OPTS);
+    expect(state.step).toBe(0);
+    computeStep(state);
+    expect(state.step).toBe(1);
+    computeStep(state);
+    expect(state.step).toBe(2);
   });
 });
 
 // ============================================================================
-// coolTemperature
-// ============================================================================
-
-describe('coolTemperature', () => {
-  it('reduces temperature each call', () => {
-    const board = makeSimpleBoard();
-    const state = initBeautify(board, OPTS);
-    const initialT = state.temperature;
-    coolTemperature(state, 0);
-    expect(state.temperature).toBeLessThan(initialT);
-  });
-
-  it('temperature approaches 0 by the final iteration', () => {
-    const board = makeSimpleBoard();
-    const state = initBeautify(board, OPTS);
-    for (let i = 0; i < state.opts.iterations; i++) {
-      coolTemperature(state, i);
-    }
-    expect(state.temperature).toBeCloseTo(0, 1);
-  });
-});
-
-// ============================================================================
-// applyPositions — grid snap
+// applyPositions
 // ============================================================================
 
 describe('applyPositions', () => {
-  it('rounds x/y to integers', () => {
-    const board = makeSimpleBoard();
-    const state = initBeautify(board, OPTS);
-    const result = applyPositions(board, state);
+  it('rounds coordinates to integers', () => {
+    const board = makeBoard();
+    const result = applyPositions(board, initBeautify(board, OPTS));
     for (const spot of result.spots) {
       expect(Number.isInteger(spot.x)).toBe(true);
       expect(Number.isInteger(spot.y)).toBe(true);
@@ -268,47 +304,50 @@ describe('applyPositions', () => {
   });
 
   it('snaps free spots to grid when gridSnap is true', () => {
-    const board = makeSimpleBoard();
+    const board = makeBoard();
     const state = initBeautify(board, { ...OPTS, gridSnap: true, gridCellSize: 50 });
     const result = applyPositions(board, state);
-    const freeSpots = result.spots.filter((s) => !state.fixed.has(s.id));
-    for (const spot of freeSpots) {
+    for (const spot of result.spots.filter((s) => !state.fixed.has(s.id))) {
       expect(spot.x % 50).toBe(0);
       expect(spot.y % 50).toBe(0);
     }
   });
 
   it('does not snap fixed spots even when gridSnap is true', () => {
-    const board = makeSimpleBoard();
+    const board = makeBoard();
     const state = initBeautify(board, { ...OPTS, gridSnap: true, gridCellSize: 50 });
-    // Force a non-grid-aligned position on a fixed spot
     const [fixedId] = state.fixed;
-    state.positions.set(fixedId, { x: 123, y: 456 });
+    // Force an off-grid target
+    state.targetPositions.set(fixedId, { x: 123, y: 456 });
     const result = applyPositions(board, state);
-    const fixedSpot = result.spots.find((s) => s.id === fixedId)!;
-    expect(fixedSpot.x).toBe(123);
-    expect(fixedSpot.y).toBe(456);
+    const spot = result.spots.find((s) => s.id === fixedId)!;
+    expect(spot.x).toBe(123);
+    expect(spot.y).toBe(456);
   });
 });
 
 // ============================================================================
-// Single-entry-spot edge case
+// Edge cases
 // ============================================================================
 
 describe('single entry spot per player', () => {
-  it('places a lone entry spot at x = width/2', () => {
+  it('centers the lone entry spot at bench center x', () => {
+    const { benchMinX, benchMaxX } = OPTS as Required<BeautifyOptions>;
+    const centerX = (benchMinX! + benchMaxX!) / 2;
     const board: Board = {
-      id: 't',
-      name: '',
+      id: 't', name: '',
       spots: [
         makeSpot('e1', 300, 480, 'entry', 1),
-        makeSpot('e2', 300, 20, 'entry', 2),
+        makeSpot('e2', 300,  20, 'entry', 2),
         makeSpot('n1', 300, 250),
       ],
-      passages: [makePassage('p1', 'e1', 'n1'), makePassage('p2', 'n1', 'e2')],
+      passages: [
+        makePassage('p1', 'e1', 'n1'),
+        makePassage('p2', 'n1', 'e2'),
+      ],
     };
     const state = initBeautify(board, OPTS);
-    const pos = state.positions.get('e1')!;
-    expect(pos.x).toBeCloseTo(500, 0); // width/2 = 500
+    expect(state.targetPositions.get('e1')!.x).toBeCloseTo(centerX, 0);
+    expect(state.targetPositions.get('e2')!.x).toBeCloseTo(centerX, 0);
   });
 });

--- a/libs/board/src/lib/utils/beautify.utils.spec.ts
+++ b/libs/board/src/lib/utils/beautify.utils.spec.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect } from 'vitest';
+import { Board, Spot, Passage } from '../models/board.models';
+import {
+  beautifyBoard,
+  initBeautify,
+  runFRStep,
+  coolTemperature,
+  applyPositions,
+  BeautifyOptions,
+} from './beautify.utils';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+function makeSpot(
+  id: string,
+  x: number,
+  y: number,
+  type: 'normal' | 'entry' | 'flag' = 'normal',
+  playerId = 1,
+): Spot {
+  return {
+    id,
+    name: '',
+    x,
+    y,
+    metadata:
+      type === 'normal'
+        ? { type: 'normal' }
+        : { type, playerId },
+  };
+}
+
+function makePassage(id: string, from: string, to: string): Passage {
+  return { id, fromSpotId: from, toSpotId: to, passageType: 'normal' };
+}
+
+/** A minimal 2-player board: 2 entries, 2 flags, 4 normal spots in a chain */
+function makeSimpleBoard(): Board {
+  return {
+    id: 'test',
+    name: 'Test',
+    spots: [
+      makeSpot('e1', 100, 480, 'entry', 1), // P1 entry — bottom-ish
+      makeSpot('e2', 900, 480, 'entry', 1), // P1 entry — bottom-ish
+      makeSpot('f1', 500, 480, 'flag', 1),  // P1 flag
+      makeSpot('e3', 100,  20, 'entry', 2), // P2 entry — top-ish
+      makeSpot('e4', 900,  20, 'entry', 2), // P2 entry — top-ish
+      makeSpot('f2', 500,  20, 'flag', 2),  // P2 flag
+      makeSpot('n1', 110, 100),              // normal — clustered
+      makeSpot('n2', 120, 110),              // normal — clustered
+      makeSpot('n3', 130, 390),              // normal — clustered
+      makeSpot('n4', 140, 400),              // normal — clustered
+    ],
+    passages: [
+      makePassage('p1', 'e1', 'n1'),
+      makePassage('p2', 'n1', 'n2'),
+      makePassage('p3', 'n2', 'e3'),
+      makePassage('p4', 'e2', 'n3'),
+      makePassage('p5', 'n3', 'n4'),
+      makePassage('p6', 'n4', 'e4'),
+      makePassage('p7', 'n1', 'n3'),
+    ],
+  };
+}
+
+const OPTS: BeautifyOptions = { iterations: 50, padding: 50, width: 1000, height: 500 };
+
+// ============================================================================
+// beautifyBoard — full pipeline
+// ============================================================================
+
+describe('beautifyBoard', () => {
+  it('returns original board unchanged when there are no spots', () => {
+    const empty: Board = { id: 'e', name: '', spots: [], passages: [] };
+    expect(beautifyBoard(empty)).toBe(empty);
+  });
+
+  it('does not mutate the original board', () => {
+    const board = makeSimpleBoard();
+    const originalPositions = board.spots.map((s) => ({ id: s.id, x: s.x, y: s.y }));
+    beautifyBoard(board, OPTS);
+    board.spots.forEach((s, i) => {
+      expect(s.x).toBe(originalPositions[i].x);
+      expect(s.y).toBe(originalPositions[i].y);
+    });
+  });
+
+  it('preserves passages (topology unchanged)', () => {
+    const board = makeSimpleBoard();
+    const result = beautifyBoard(board, OPTS);
+    expect(result.passages).toEqual(board.passages);
+  });
+
+  it('keeps all free (normal) spots within [padding, width-padding] × [padding, height-padding]', () => {
+    const { padding, width, height } = OPTS as Required<BeautifyOptions>;
+    const board = makeSimpleBoard();
+    const state = initBeautify(board, OPTS);
+    const result = beautifyBoard(board, OPTS);
+    // Fixed spots (entry/flag) keep their pre-positioned or current coordinates
+    // and are not subject to the boundary clamp.  Only free spots are constrained.
+    for (const spot of result.spots) {
+      if (state.fixed.has(spot.id)) continue;
+      expect(spot.x).toBeGreaterThanOrEqual(padding);
+      expect(spot.x).toBeLessThanOrEqual(width - padding);
+      expect(spot.y).toBeGreaterThanOrEqual(padding);
+      expect(spot.y).toBeLessThanOrEqual(height - padding);
+    }
+  });
+
+  it('returns the correct number of spots', () => {
+    const board = makeSimpleBoard();
+    const result = beautifyBoard(board, OPTS);
+    expect(result.spots).toHaveLength(board.spots.length);
+  });
+});
+
+// ============================================================================
+// initBeautify — entry spot pre-positioning
+// ============================================================================
+
+describe('initBeautify — entry spot pre-positioning', () => {
+  it('moves P1 entry spots to the bottom edge (y = height - padding)', () => {
+    const { padding, height } = OPTS as Required<BeautifyOptions>;
+    const state = initBeautify(makeSimpleBoard(), OPTS);
+    const p1Entries = makeSimpleBoard().spots.filter(
+      (s) => s.metadata.type === 'entry' && 'playerId' in s.metadata && s.metadata.playerId === 1,
+    );
+    for (const spot of p1Entries) {
+      const pos = state.positions.get(spot.id)!;
+      expect(pos.y).toBe(height! - padding!);
+    }
+  });
+
+  it('moves P2 entry spots to the top edge (y = padding)', () => {
+    const { padding } = OPTS as Required<BeautifyOptions>;
+    const state = initBeautify(makeSimpleBoard(), OPTS);
+    const p2Entries = makeSimpleBoard().spots.filter(
+      (s) => s.metadata.type === 'entry' && 'playerId' in s.metadata && s.metadata.playerId === 2,
+    );
+    for (const spot of p2Entries) {
+      const pos = state.positions.get(spot.id)!;
+      expect(pos.y).toBe(padding!);
+    }
+  });
+
+  it('distributes multiple entry spots evenly across x', () => {
+    const { padding, width } = OPTS as Required<BeautifyOptions>;
+    const state = initBeautify(makeSimpleBoard(), OPTS);
+    // P1 has 2 entry spots — should be at x=padding and x=width-padding
+    const p1Entries = makeSimpleBoard()
+      .spots.filter(
+        (s) => s.metadata.type === 'entry' && 'playerId' in s.metadata && s.metadata.playerId === 1,
+      )
+      .sort((a, b) => a.x - b.x);
+
+    const xs = p1Entries.map((s) => state.positions.get(s.id)!.x);
+    expect(Math.min(...xs)).toBeCloseTo(padding!, 0);
+    expect(Math.max(...xs)).toBeCloseTo(width! - padding!, 0);
+  });
+
+  it('pins entry spots in the fixed set', () => {
+    const board = makeSimpleBoard();
+    const state = initBeautify(board, OPTS);
+    const entryIds = board.spots
+      .filter((s) => s.metadata.type === 'entry')
+      .map((s) => s.id);
+    for (const id of entryIds) {
+      expect(state.fixed.has(id)).toBe(true);
+    }
+  });
+
+  it('pins flag spots in the fixed set', () => {
+    const board = makeSimpleBoard();
+    const state = initBeautify(board, OPTS);
+    const flagIds = board.spots.filter((s) => s.metadata.type === 'flag').map((s) => s.id);
+    for (const id of flagIds) {
+      expect(state.fixed.has(id)).toBe(true);
+    }
+  });
+
+  it('does not pin normal spots', () => {
+    const board = makeSimpleBoard();
+    const state = initBeautify(board, OPTS);
+    const normalIds = board.spots.filter((s) => s.metadata.type === 'normal').map((s) => s.id);
+    for (const id of normalIds) {
+      expect(state.fixed.has(id)).toBe(false);
+    }
+  });
+});
+
+// ============================================================================
+// runFRStep — positions evolve, fixed spots stay put
+// ============================================================================
+
+describe('runFRStep', () => {
+  it('does not move fixed spots', () => {
+    const board = makeSimpleBoard();
+    const state = initBeautify(board, OPTS);
+
+    const before = new Map<string, { x: number; y: number }>();
+    for (const [id, pos] of state.positions) {
+      before.set(id, { ...pos });
+    }
+
+    runFRStep(board.spots, board.passages, state);
+
+    for (const id of state.fixed) {
+      expect(state.positions.get(id)).toEqual(before.get(id));
+    }
+  });
+
+  it('moves at least one free spot when spots are clustered', () => {
+    const board = makeSimpleBoard();
+    const state = initBeautify(board, OPTS);
+    const freeIds = board.spots
+      .filter((s) => !state.fixed.has(s.id))
+      .map((s) => s.id);
+
+    const before = freeIds.map((id) => ({ ...state.positions.get(id)! }));
+    runFRStep(board.spots, board.passages, state);
+    const after = freeIds.map((id) => ({ ...state.positions.get(id)! }));
+
+    const anyMoved = freeIds.some((_, i) => {
+      return before[i].x !== after[i].x || before[i].y !== after[i].y;
+    });
+    expect(anyMoved).toBe(true);
+  });
+});
+
+// ============================================================================
+// coolTemperature
+// ============================================================================
+
+describe('coolTemperature', () => {
+  it('reduces temperature each call', () => {
+    const board = makeSimpleBoard();
+    const state = initBeautify(board, OPTS);
+    const initialT = state.temperature;
+    coolTemperature(state, 0);
+    expect(state.temperature).toBeLessThan(initialT);
+  });
+
+  it('temperature approaches 0 by the final iteration', () => {
+    const board = makeSimpleBoard();
+    const state = initBeautify(board, OPTS);
+    for (let i = 0; i < state.opts.iterations; i++) {
+      coolTemperature(state, i);
+    }
+    expect(state.temperature).toBeCloseTo(0, 1);
+  });
+});
+
+// ============================================================================
+// applyPositions — grid snap
+// ============================================================================
+
+describe('applyPositions', () => {
+  it('rounds x/y to integers', () => {
+    const board = makeSimpleBoard();
+    const state = initBeautify(board, OPTS);
+    const result = applyPositions(board, state);
+    for (const spot of result.spots) {
+      expect(Number.isInteger(spot.x)).toBe(true);
+      expect(Number.isInteger(spot.y)).toBe(true);
+    }
+  });
+
+  it('snaps free spots to grid when gridSnap is true', () => {
+    const board = makeSimpleBoard();
+    const state = initBeautify(board, { ...OPTS, gridSnap: true, gridCellSize: 50 });
+    const result = applyPositions(board, state);
+    const freeSpots = result.spots.filter((s) => !state.fixed.has(s.id));
+    for (const spot of freeSpots) {
+      expect(spot.x % 50).toBe(0);
+      expect(spot.y % 50).toBe(0);
+    }
+  });
+
+  it('does not snap fixed spots even when gridSnap is true', () => {
+    const board = makeSimpleBoard();
+    const state = initBeautify(board, { ...OPTS, gridSnap: true, gridCellSize: 50 });
+    // Force a non-grid-aligned position on a fixed spot
+    const [fixedId] = state.fixed;
+    state.positions.set(fixedId, { x: 123, y: 456 });
+    const result = applyPositions(board, state);
+    const fixedSpot = result.spots.find((s) => s.id === fixedId)!;
+    expect(fixedSpot.x).toBe(123);
+    expect(fixedSpot.y).toBe(456);
+  });
+});
+
+// ============================================================================
+// Single-entry-spot edge case
+// ============================================================================
+
+describe('single entry spot per player', () => {
+  it('places a lone entry spot at x = width/2', () => {
+    const board: Board = {
+      id: 't',
+      name: '',
+      spots: [
+        makeSpot('e1', 300, 480, 'entry', 1),
+        makeSpot('e2', 300, 20, 'entry', 2),
+        makeSpot('n1', 300, 250),
+      ],
+      passages: [makePassage('p1', 'e1', 'n1'), makePassage('p2', 'n1', 'e2')],
+    };
+    const state = initBeautify(board, OPTS);
+    const pos = state.positions.get('e1')!;
+    expect(pos.x).toBeCloseTo(500, 0); // width/2 = 500
+  });
+});

--- a/libs/board/src/lib/utils/beautify.utils.ts
+++ b/libs/board/src/lib/utils/beautify.utils.ts
@@ -1,13 +1,26 @@
 /**
  * Board Beautify Utilities
  *
- * Implements a constrained Fruchterman-Reingold force-directed layout algorithm
- * to improve the visual appearance of custom boards without changing their topology.
+ * Three-phase layout algorithm designed for 2-player game boards:
  *
- * Phase 0 — Pre-position entry spots near their bench edges
- * Phase 1 — Pin entry + flag spots; free spots float
- * Phase 2 — Fruchterman-Reingold iterations (repulsion + spring attraction)
- * Phase 3 — Optional grid snap on non-fixed spots
+ * Phase 0 — Anchor spots
+ *   • Entry spots → bench edge (y), evenly distributed within bench x range
+ *   • Flag spots  → center of bench (x), same y as their player's entry spots
+ *
+ * Phase 1 — BFS y-assignment
+ *   Multi-source BFS from each player's entry spots gives every free spot a
+ *   "depth ratio" (0 = bottom-player side, 1 = top-player side) which maps
+ *   directly to a y coordinate.  This respects game flow far better than
+ *   force-directed, which has no notion of "player sides".
+ *
+ * Phase 2 — X-only force-direction
+ *   With y locked to the BFS layers, a constrained Fruchterman-Reingold pass
+ *   (repulsion + spring attraction, x component only) distributes spots
+ *   horizontally and reduces within-layer crossings.
+ *
+ * Animation
+ *   The store drives a smooth eased lerp from each spot's start position to
+ *   its computed target — one `computeStep()` call per requestAnimationFrame.
  */
 
 import { Board, Passage, Spot } from '../models/board.models';
@@ -18,35 +31,54 @@ import { snapToGrid } from './grid.utils';
 // ============================================================================
 
 export interface BeautifyOptions {
-  /** Number of F-R iterations to run. Default: 300 */
-  iterations?: number;
-  /** Iterations to run per animation frame. Default: 5 */
-  stepsPerFrame?: number;
+  /** F-R iterations for x-only distribution after BFS. Default: 150 */
+  frIterations?: number;
+  /** Number of rAF frames for the lerp animation. Default: 60 */
+  animationFrames?: number;
   /** Padding from board edges (px). Default: 50 */
   padding?: number;
   /** Board canvas width (px). Default: 1000 */
   width?: number;
   /** Board canvas height (px). Default: 500 */
   height?: number;
+  /**
+   * X position of the leftmost bench slot — entry spots are distributed
+   * within [benchMinX, benchMaxX], not the full board width.
+   * Default: 200
+   */
+  benchMinX?: number;
+  /**
+   * X position of the rightmost bench slot.
+   * Default: 800
+   */
+  benchMaxX?: number;
   /** Snap non-fixed spots to grid after layout. Default: false */
   gridSnap?: boolean;
   /** Grid cell size when gridSnap is true. Default: 50 */
   gridCellSize?: number;
 }
 
-/** Mutable position map used during layout computation */
+/** Mutable position map shared between algorithm phases */
 export type PositionMap = Map<string, { x: number; y: number }>;
 
-/** All state needed to drive a step-by-step animated layout */
+/**
+ * All state needed to drive a frame-by-frame animated layout.
+ * `currentPositions` is lerped from `startPositions` toward `targetPositions`
+ * on each `computeStep()` call.
+ */
 export interface BeautifyState {
-  /** Current positions of all spots (mutated each step) */
-  positions: PositionMap;
-  /** IDs of spots that must not move */
+  /** Positions when beautify was triggered (lerp origin) */
+  startPositions: PositionMap;
+  /** Fully-computed target positions from the layout algorithm */
+  targetPositions: PositionMap;
+  /** Interpolated positions updated each animation frame */
+  currentPositions: PositionMap;
+  /** IDs of spots that must not move (entry + flag) */
   fixed: Set<string>;
-  /** Ideal spring length — sqrt(area / n) */
-  k: number;
-  /** Current temperature (decreases each iteration) */
-  temperature: number;
+  /** Current animation frame index */
+  step: number;
+  /** Total animation frames (from opts.animationFrames) */
+  totalSteps: number;
   /** Resolved options with all defaults applied */
   opts: Required<BeautifyOptions>;
 }
@@ -56,11 +88,13 @@ export interface BeautifyState {
 // ============================================================================
 
 const DEFAULTS: Required<BeautifyOptions> = {
-  iterations: 300,
-  stepsPerFrame: 5,
+  frIterations: 150,
+  animationFrames: 60,
   padding: 50,
   width: 1000,
   height: 500,
+  benchMinX: 200,
+  benchMaxX: 800,
   gridSnap: false,
   gridCellSize: 50,
 };
@@ -69,50 +103,215 @@ const DEFAULTS: Required<BeautifyOptions> = {
 // Internal Helpers
 // ============================================================================
 
+/** Multi-source BFS — returns minimum hop-distance from any source to each spot */
+function bfsDistances(passages: Passage[], sourceIds: string[]): Map<string, number> {
+  // Build adjacency list from passages
+  const adj = new Map<string, string[]>();
+  for (const p of passages) {
+    if (!adj.has(p.fromSpotId)) adj.set(p.fromSpotId, []);
+    if (!adj.has(p.toSpotId)) adj.set(p.toSpotId, []);
+    adj.get(p.fromSpotId)!.push(p.toSpotId);
+    adj.get(p.toSpotId)!.push(p.fromSpotId);
+  }
+
+  const dist = new Map<string, number>();
+  const queue: string[] = [];
+
+  for (const id of sourceIds) {
+    if (!dist.has(id)) {
+      dist.set(id, 0);
+      queue.push(id);
+    }
+  }
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const d = dist.get(current)!;
+    for (const neighbor of adj.get(current) ?? []) {
+      if (!dist.has(neighbor)) {
+        dist.set(neighbor, d + 1);
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  return dist;
+}
+
+/** Smooth easing for animation */
+function easeInOutCubic(t: number): number {
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+}
+
 /**
- * Phase 0: Move each player's entry spots to the board edge closest to their
- * bench, distributed evenly across the board width.
- *
- * "Closest bench edge" is determined by the current average y of each player's
- * entry spots: avg y > height/2 → bottom edge, otherwise → top edge.
- *
- * Returns the set of spot IDs that were repositioned (they are then pinned).
+ * Compute the full target layout for the board.
+ * Returns positions for ALL spots (fixed and free) and the fixed set.
  */
-function prePositionEntrySpots(
+function computeTargetLayout(
   spots: Spot[],
-  positions: PositionMap,
+  passages: Passage[],
   opts: Required<BeautifyOptions>,
-): Set<string> {
-  const { padding, width, height } = opts;
+): { positions: PositionMap; fixed: Set<string> } {
+  const { padding, width, height, benchMinX, benchMaxX, frIterations } = opts;
+
+  const positions: PositionMap = new Map(spots.map((s) => [s.id, { x: s.x, y: s.y }]));
   const fixed = new Set<string>();
 
-  // Group entry spots by player
-  const byPlayer = new Map<number, Spot[]>();
+  if (spots.length === 0) return { positions, fixed };
+
+  // ===========================================================================
+  // Phase 0: Anchor spots (entry + flag)
+  // ===========================================================================
+
+  // Group entry spots by player; infer each player's vertical side from avg y
+  const entryByPlayer = new Map<number, Spot[]>();
   for (const spot of spots) {
     if (spot.metadata.type !== 'entry') continue;
     const pid = spot.metadata.playerId;
-    if (!byPlayer.has(pid)) byPlayer.set(pid, []);
-    byPlayer.get(pid)!.push(spot);
+    if (!entryByPlayer.has(pid)) entryByPlayer.set(pid, []);
+    entryByPlayer.get(pid)!.push(spot);
   }
 
-  for (const entrySpots of byPlayer.values()) {
-    // Determine vertical side from current average y
-    const avgY = entrySpots.reduce((sum, s) => sum + s.y, 0) / entrySpots.length;
+  // Target y per player (bottom edge or top edge of board)
+  const playerTargetY = new Map<number, number>();
+  for (const [pid, entrySpots] of entryByPlayer) {
+    const avgY = entrySpots.reduce((s, e) => s + e.y, 0) / entrySpots.length;
     const isBottom = avgY > height / 2;
-    const targetY = isBottom ? height - padding : padding;
+    playerTargetY.set(pid, isBottom ? height - padding : padding);
+  }
 
-    // Sort left-to-right by current x, then distribute evenly across width
+  // Place entry spots: y = bench edge, x distributed evenly within bench range
+  for (const [pid, entrySpots] of entryByPlayer) {
+    const targetY = playerTargetY.get(pid)!;
     const sorted = [...entrySpots].sort((a, b) => a.x - b.x);
     const n = sorted.length;
     for (let i = 0; i < n; i++) {
       const t = n === 1 ? 0.5 : i / (n - 1);
-      const x = padding + t * (width - 2 * padding);
+      const x = benchMinX + t * (benchMaxX - benchMinX);
       positions.set(sorted[i].id, { x, y: targetY });
       fixed.add(sorted[i].id);
     }
   }
 
-  return fixed;
+  // Place flag spots: x = center of bench, y = same as player's entry spots
+  // If no entry info for a player, fall back to their current vertical side.
+  for (const spot of spots) {
+    if (spot.metadata.type !== 'flag') continue;
+    const pid = spot.metadata.playerId;
+    const targetY =
+      playerTargetY.get(pid) ?? (spot.y > height / 2 ? height - padding : padding);
+    const x = (benchMinX + benchMaxX) / 2;
+    positions.set(spot.id, { x, y: targetY });
+    fixed.add(spot.id);
+  }
+
+  // ===========================================================================
+  // Phase 1: BFS y-assignment for free spots
+  // ===========================================================================
+
+  // Separate entry spots into "bottom" side (large y) and "top" side (small y)
+  const bottomEntryIds: string[] = [];
+  const topEntryIds: string[] = [];
+  for (const [pid, entrySpots] of entryByPlayer) {
+    const targetY = playerTargetY.get(pid)!;
+    const ids = entrySpots.map((s) => s.id);
+    if (targetY > height / 2) {
+      bottomEntryIds.push(...ids);
+    } else {
+      topEntryIds.push(...ids);
+    }
+  }
+
+  const bottomY = height - padding;
+  const topY = padding;
+
+  // Only run BFS if we have both sides; otherwise y stays as-is
+  if (bottomEntryIds.length > 0 && topEntryIds.length > 0) {
+    const dBottom = bfsDistances(passages, bottomEntryIds);
+    const dTop = bfsDistances(passages, topEntryIds);
+
+    for (const spot of spots) {
+      if (fixed.has(spot.id)) continue;
+
+      const d1 = dBottom.get(spot.id) ?? Infinity;
+      const d2 = dTop.get(spot.id) ?? Infinity;
+
+      let ratio: number;
+      if (d1 === Infinity && d2 === Infinity) {
+        ratio = 0.5; // unreachable from either side → place in middle
+      } else if (d1 === Infinity) {
+        ratio = 1; // only reachable from top → place near top
+      } else if (d2 === Infinity) {
+        ratio = 0; // only reachable from bottom → place near bottom
+      } else {
+        // ratio=0 → closer to bottom, ratio=1 → closer to top
+        ratio = d1 / (d1 + d2);
+      }
+
+      const y = bottomY + ratio * (topY - bottomY);
+      const current = positions.get(spot.id)!;
+      positions.set(spot.id, { x: current.x, y });
+    }
+  }
+
+  // ===========================================================================
+  // Phase 2: X-only Fruchterman-Reingold
+  // Y is locked; only horizontal displacement is applied.
+  // This distributes spots within their layers and reduces crossing.
+  // ===========================================================================
+
+  const area = (width - 2 * padding) * (height - 2 * padding);
+  const k = Math.sqrt(area / Math.max(spots.length, 1));
+  let temperature = (width - 2 * padding) / 5; // tighter initial temp for x-only
+
+  for (let iter = 0; iter < frIterations; iter++) {
+    const dispX = new Map<string, number>();
+    for (const spot of spots) dispX.set(spot.id, 0);
+
+    // Repulsive forces (x component only)
+    for (let i = 0; i < spots.length; i++) {
+      for (let j = i + 1; j < spots.length; j++) {
+        const u = spots[i];
+        const v = spots[j];
+        const pu = positions.get(u.id)!;
+        const pv = positions.get(v.id)!;
+        const dx = pu.x - pv.x;
+        const dy = pu.y - pv.y;
+        const dist = Math.sqrt(dx * dx + dy * dy) || 0.01;
+        const fr = (k * k) / dist;
+        dispX.set(u.id, dispX.get(u.id)! + (dx / dist) * fr);
+        dispX.set(v.id, dispX.get(v.id)! - (dx / dist) * fr);
+      }
+    }
+
+    // Attractive forces along passages (x component only)
+    for (const passage of passages) {
+      const pu = positions.get(passage.fromSpotId);
+      const pv = positions.get(passage.toSpotId);
+      if (!pu || !pv) continue;
+      const dx = pu.x - pv.x;
+      const dy = pu.y - pv.y;
+      const dist = Math.sqrt(dx * dx + dy * dy) || 0.01;
+      const fa = (dist * dist) / k;
+      dispX.set(passage.fromSpotId, dispX.get(passage.fromSpotId)! - (dx / dist) * fa);
+      dispX.set(passage.toSpotId, dispX.get(passage.toSpotId)! + (dx / dist) * fa);
+    }
+
+    // Apply x displacements (non-fixed spots only, y unchanged)
+    for (const spot of spots) {
+      if (fixed.has(spot.id)) continue;
+      const d = dispX.get(spot.id)!;
+      const absD = Math.abs(d);
+      const scale = Math.min(absD, temperature) / (absD || 1);
+      const p = positions.get(spot.id)!;
+      p.x = Math.max(padding, Math.min(width - padding, p.x + d * scale));
+    }
+
+    // Cool temperature linearly
+    temperature *= 1 - (iter + 1) / frIterations;
+  }
+
+  return { positions, fixed };
 }
 
 // ============================================================================
@@ -120,127 +319,76 @@ function prePositionEntrySpots(
 // ============================================================================
 
 /**
- * Initialise all state required to run the beautify algorithm.
+ * Initialise all state required to animate the beautify algorithm.
  *
- * Call this once, then drive iteration with `runFRStep`, then apply results
- * with `applyPositions`. Or just call `beautifyBoard` for the full pipeline.
+ * Computes the full target layout synchronously (BFS + x-only F-R), then
+ * stores both the start and target positions so the caller can drive a
+ * smooth lerp via `computeStep()`.
  */
 export function initBeautify(board: Board, options?: BeautifyOptions): BeautifyState {
   const opts: Required<BeautifyOptions> = { ...DEFAULTS, ...options };
-  const { padding, width, height } = opts;
 
-  // Copy current positions (we mutate these in place during layout)
-  const positions: PositionMap = new Map(board.spots.map((s) => [s.id, { x: s.x, y: s.y }]));
+  const startPositions: PositionMap = new Map(
+    board.spots.map((s) => [s.id, { x: s.x, y: s.y }]),
+  );
 
-  // Phase 0: pre-position entry spots near bench edges and mark them fixed
-  const fixed = prePositionEntrySpots(board.spots, positions, opts);
+  const { positions: targetPositions, fixed } = computeTargetLayout(
+    board.spots,
+    board.passages,
+    opts,
+  );
 
-  // Phase 1: also pin flag spots at their current positions
-  for (const spot of board.spots) {
-    if (spot.metadata.type === 'flag') {
-      fixed.add(spot.id);
-    }
-  }
+  // currentPositions starts at the start; computeStep() lerps it toward target
+  const currentPositions: PositionMap = new Map(
+    board.spots.map((s) => [s.id, { x: s.x, y: s.y }]),
+  );
 
-  const area = (width - 2 * padding) * (height - 2 * padding);
-  const k = Math.sqrt(area / Math.max(board.spots.length, 1));
-  const temperature = width / 10;
-
-  return { positions, fixed, k, temperature, opts };
+  return {
+    startPositions,
+    targetPositions,
+    currentPositions,
+    fixed,
+    step: 0,
+    totalSteps: opts.animationFrames,
+    opts,
+  };
 }
 
 /**
- * Run one iteration of Fruchterman-Reingold.
+ * Advance the animation by one frame.
  *
- * Mutates `state.positions` in place.
- * Call this in a loop (or per animation frame), decrementing `state.temperature`
- * after each call using `coolTemperature`.
+ * Lerps `currentPositions` toward `targetPositions` using a cubic ease-in-out.
+ * Returns `true` when the animation is complete (step >= totalSteps).
  */
-export function runFRStep(
-  spots: Spot[],
-  passages: Passage[],
-  state: BeautifyState,
-): void {
-  const { positions, fixed, k, temperature, opts } = state;
-  const { padding, width, height } = opts;
+export function computeStep(state: BeautifyState): boolean {
+  state.step++;
+  const t = easeInOutCubic(Math.min(state.step / state.totalSteps, 1));
 
-  // Accumulate displacement for each spot
-  const displacement = new Map<string, { x: number; y: number }>();
-  for (const spot of spots) {
-    displacement.set(spot.id, { x: 0, y: 0 });
+  for (const [id, start] of state.startPositions) {
+    if (state.fixed.has(id)) continue;
+    const target = state.targetPositions.get(id)!;
+    state.currentPositions.set(id, {
+      x: start.x + (target.x - start.x) * t,
+      y: start.y + (target.y - start.y) * t,
+    });
   }
 
-  // Repulsive forces — every pair of spots pushes each other apart
-  for (let i = 0; i < spots.length; i++) {
-    for (let j = i + 1; j < spots.length; j++) {
-      const u = spots[i];
-      const v = spots[j];
-      const pu = positions.get(u.id)!;
-      const pv = positions.get(v.id)!;
-      const dx = pu.x - pv.x;
-      const dy = pu.y - pv.y;
-      const dist = Math.sqrt(dx * dx + dy * dy) || 0.01;
-      const fr = (k * k) / dist;
-      const du = displacement.get(u.id)!;
-      const dv = displacement.get(v.id)!;
-      du.x += (dx / dist) * fr;
-      du.y += (dy / dist) * fr;
-      dv.x -= (dx / dist) * fr;
-      dv.y -= (dy / dist) * fr;
-    }
-  }
-
-  // Attractive forces — each passage pulls its two spots together
-  for (const passage of passages) {
-    const pu = positions.get(passage.fromSpotId);
-    const pv = positions.get(passage.toSpotId);
-    if (!pu || !pv) continue;
-    const dx = pu.x - pv.x;
-    const dy = pu.y - pv.y;
-    const dist = Math.sqrt(dx * dx + dy * dy) || 0.01;
-    const fa = (dist * dist) / k;
-    const du = displacement.get(passage.fromSpotId)!;
-    const dv = displacement.get(passage.toSpotId)!;
-    du.x -= (dx / dist) * fa;
-    du.y -= (dy / dist) * fa;
-    dv.x += (dx / dist) * fa;
-    dv.y += (dy / dist) * fa;
-  }
-
-  // Apply displacement — only to non-fixed spots, capped by temperature
-  for (const spot of spots) {
-    if (fixed.has(spot.id)) continue;
-    const d = displacement.get(spot.id)!;
-    const p = positions.get(spot.id)!;
-    const dist = Math.sqrt(d.x * d.x + d.y * d.y) || 0.01;
-    const scale = Math.min(dist, temperature) / dist;
-    p.x = Math.max(padding, Math.min(width - padding, p.x + d.x * scale));
-    p.y = Math.max(padding, Math.min(height - padding, p.y + d.y * scale));
-  }
+  return state.step >= state.totalSteps;
 }
 
 /**
- * Cool the temperature after an iteration.
- * Uses linear cooling: T_i = T_0 * (1 - i/N).
- */
-export function coolTemperature(state: BeautifyState, iter: number): void {
-  state.temperature *= 1 - (iter + 1) / state.opts.iterations;
-}
-
-/**
- * Apply final positions from `state` back to a board, returning a new Board.
- * Optionally snaps non-fixed spots to the grid.
- *
- * Does not mutate the original board or spots.
+ * Write the final target positions back to a Board, returning a new Board.
+ * Applies optional grid snap to non-fixed spots.
+ * Does not mutate the original board.
  */
 export function applyPositions(board: Board, state: BeautifyState): Board {
-  const { positions, fixed, opts } = state;
+  const { targetPositions, fixed, opts } = state;
   const { gridSnap, gridCellSize } = opts;
 
   return {
     ...board,
     spots: board.spots.map((spot) => {
-      const p = positions.get(spot.id)!;
+      const p = targetPositions.get(spot.id)!;
       let x = Math.round(p.x);
       let y = Math.round(p.y);
       if (gridSnap && !fixed.has(spot.id)) {
@@ -255,19 +403,11 @@ export function applyPositions(board: Board, state: BeautifyState): Board {
 /**
  * Instant full-pipeline beautify.
  *
- * Runs all iterations synchronously and returns a new Board.
- * Use `initBeautify` + `runFRStep` + `coolTemperature` for the animated path.
+ * Computes and applies the layout in one synchronous call.
+ * Use `initBeautify` + `computeStep` for the animated path.
  */
 export function beautifyBoard(board: Board, options?: BeautifyOptions): Board {
   if (board.spots.length === 0) return board;
-
   const state = initBeautify(board, options);
-  const { iterations } = state.opts;
-
-  for (let iter = 0; iter < iterations; iter++) {
-    runFRStep(board.spots, board.passages, state);
-    coolTemperature(state, iter);
-  }
-
   return applyPositions(board, state);
 }

--- a/libs/board/src/lib/utils/beautify.utils.ts
+++ b/libs/board/src/lib/utils/beautify.utils.ts
@@ -1,0 +1,273 @@
+/**
+ * Board Beautify Utilities
+ *
+ * Implements a constrained Fruchterman-Reingold force-directed layout algorithm
+ * to improve the visual appearance of custom boards without changing their topology.
+ *
+ * Phase 0 — Pre-position entry spots near their bench edges
+ * Phase 1 — Pin entry + flag spots; free spots float
+ * Phase 2 — Fruchterman-Reingold iterations (repulsion + spring attraction)
+ * Phase 3 — Optional grid snap on non-fixed spots
+ */
+
+import { Board, Passage, Spot } from '../models/board.models';
+import { snapToGrid } from './grid.utils';
+
+// ============================================================================
+// Public Types
+// ============================================================================
+
+export interface BeautifyOptions {
+  /** Number of F-R iterations to run. Default: 300 */
+  iterations?: number;
+  /** Iterations to run per animation frame. Default: 5 */
+  stepsPerFrame?: number;
+  /** Padding from board edges (px). Default: 50 */
+  padding?: number;
+  /** Board canvas width (px). Default: 1000 */
+  width?: number;
+  /** Board canvas height (px). Default: 500 */
+  height?: number;
+  /** Snap non-fixed spots to grid after layout. Default: false */
+  gridSnap?: boolean;
+  /** Grid cell size when gridSnap is true. Default: 50 */
+  gridCellSize?: number;
+}
+
+/** Mutable position map used during layout computation */
+export type PositionMap = Map<string, { x: number; y: number }>;
+
+/** All state needed to drive a step-by-step animated layout */
+export interface BeautifyState {
+  /** Current positions of all spots (mutated each step) */
+  positions: PositionMap;
+  /** IDs of spots that must not move */
+  fixed: Set<string>;
+  /** Ideal spring length — sqrt(area / n) */
+  k: number;
+  /** Current temperature (decreases each iteration) */
+  temperature: number;
+  /** Resolved options with all defaults applied */
+  opts: Required<BeautifyOptions>;
+}
+
+// ============================================================================
+// Defaults
+// ============================================================================
+
+const DEFAULTS: Required<BeautifyOptions> = {
+  iterations: 300,
+  stepsPerFrame: 5,
+  padding: 50,
+  width: 1000,
+  height: 500,
+  gridSnap: false,
+  gridCellSize: 50,
+};
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+/**
+ * Phase 0: Move each player's entry spots to the board edge closest to their
+ * bench, distributed evenly across the board width.
+ *
+ * "Closest bench edge" is determined by the current average y of each player's
+ * entry spots: avg y > height/2 → bottom edge, otherwise → top edge.
+ *
+ * Returns the set of spot IDs that were repositioned (they are then pinned).
+ */
+function prePositionEntrySpots(
+  spots: Spot[],
+  positions: PositionMap,
+  opts: Required<BeautifyOptions>,
+): Set<string> {
+  const { padding, width, height } = opts;
+  const fixed = new Set<string>();
+
+  // Group entry spots by player
+  const byPlayer = new Map<number, Spot[]>();
+  for (const spot of spots) {
+    if (spot.metadata.type !== 'entry') continue;
+    const pid = spot.metadata.playerId;
+    if (!byPlayer.has(pid)) byPlayer.set(pid, []);
+    byPlayer.get(pid)!.push(spot);
+  }
+
+  for (const entrySpots of byPlayer.values()) {
+    // Determine vertical side from current average y
+    const avgY = entrySpots.reduce((sum, s) => sum + s.y, 0) / entrySpots.length;
+    const isBottom = avgY > height / 2;
+    const targetY = isBottom ? height - padding : padding;
+
+    // Sort left-to-right by current x, then distribute evenly across width
+    const sorted = [...entrySpots].sort((a, b) => a.x - b.x);
+    const n = sorted.length;
+    for (let i = 0; i < n; i++) {
+      const t = n === 1 ? 0.5 : i / (n - 1);
+      const x = padding + t * (width - 2 * padding);
+      positions.set(sorted[i].id, { x, y: targetY });
+      fixed.add(sorted[i].id);
+    }
+  }
+
+  return fixed;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Initialise all state required to run the beautify algorithm.
+ *
+ * Call this once, then drive iteration with `runFRStep`, then apply results
+ * with `applyPositions`. Or just call `beautifyBoard` for the full pipeline.
+ */
+export function initBeautify(board: Board, options?: BeautifyOptions): BeautifyState {
+  const opts: Required<BeautifyOptions> = { ...DEFAULTS, ...options };
+  const { padding, width, height } = opts;
+
+  // Copy current positions (we mutate these in place during layout)
+  const positions: PositionMap = new Map(board.spots.map((s) => [s.id, { x: s.x, y: s.y }]));
+
+  // Phase 0: pre-position entry spots near bench edges and mark them fixed
+  const fixed = prePositionEntrySpots(board.spots, positions, opts);
+
+  // Phase 1: also pin flag spots at their current positions
+  for (const spot of board.spots) {
+    if (spot.metadata.type === 'flag') {
+      fixed.add(spot.id);
+    }
+  }
+
+  const area = (width - 2 * padding) * (height - 2 * padding);
+  const k = Math.sqrt(area / Math.max(board.spots.length, 1));
+  const temperature = width / 10;
+
+  return { positions, fixed, k, temperature, opts };
+}
+
+/**
+ * Run one iteration of Fruchterman-Reingold.
+ *
+ * Mutates `state.positions` in place.
+ * Call this in a loop (or per animation frame), decrementing `state.temperature`
+ * after each call using `coolTemperature`.
+ */
+export function runFRStep(
+  spots: Spot[],
+  passages: Passage[],
+  state: BeautifyState,
+): void {
+  const { positions, fixed, k, temperature, opts } = state;
+  const { padding, width, height } = opts;
+
+  // Accumulate displacement for each spot
+  const displacement = new Map<string, { x: number; y: number }>();
+  for (const spot of spots) {
+    displacement.set(spot.id, { x: 0, y: 0 });
+  }
+
+  // Repulsive forces — every pair of spots pushes each other apart
+  for (let i = 0; i < spots.length; i++) {
+    for (let j = i + 1; j < spots.length; j++) {
+      const u = spots[i];
+      const v = spots[j];
+      const pu = positions.get(u.id)!;
+      const pv = positions.get(v.id)!;
+      const dx = pu.x - pv.x;
+      const dy = pu.y - pv.y;
+      const dist = Math.sqrt(dx * dx + dy * dy) || 0.01;
+      const fr = (k * k) / dist;
+      const du = displacement.get(u.id)!;
+      const dv = displacement.get(v.id)!;
+      du.x += (dx / dist) * fr;
+      du.y += (dy / dist) * fr;
+      dv.x -= (dx / dist) * fr;
+      dv.y -= (dy / dist) * fr;
+    }
+  }
+
+  // Attractive forces — each passage pulls its two spots together
+  for (const passage of passages) {
+    const pu = positions.get(passage.fromSpotId);
+    const pv = positions.get(passage.toSpotId);
+    if (!pu || !pv) continue;
+    const dx = pu.x - pv.x;
+    const dy = pu.y - pv.y;
+    const dist = Math.sqrt(dx * dx + dy * dy) || 0.01;
+    const fa = (dist * dist) / k;
+    const du = displacement.get(passage.fromSpotId)!;
+    const dv = displacement.get(passage.toSpotId)!;
+    du.x -= (dx / dist) * fa;
+    du.y -= (dy / dist) * fa;
+    dv.x += (dx / dist) * fa;
+    dv.y += (dy / dist) * fa;
+  }
+
+  // Apply displacement — only to non-fixed spots, capped by temperature
+  for (const spot of spots) {
+    if (fixed.has(spot.id)) continue;
+    const d = displacement.get(spot.id)!;
+    const p = positions.get(spot.id)!;
+    const dist = Math.sqrt(d.x * d.x + d.y * d.y) || 0.01;
+    const scale = Math.min(dist, temperature) / dist;
+    p.x = Math.max(padding, Math.min(width - padding, p.x + d.x * scale));
+    p.y = Math.max(padding, Math.min(height - padding, p.y + d.y * scale));
+  }
+}
+
+/**
+ * Cool the temperature after an iteration.
+ * Uses linear cooling: T_i = T_0 * (1 - i/N).
+ */
+export function coolTemperature(state: BeautifyState, iter: number): void {
+  state.temperature *= 1 - (iter + 1) / state.opts.iterations;
+}
+
+/**
+ * Apply final positions from `state` back to a board, returning a new Board.
+ * Optionally snaps non-fixed spots to the grid.
+ *
+ * Does not mutate the original board or spots.
+ */
+export function applyPositions(board: Board, state: BeautifyState): Board {
+  const { positions, fixed, opts } = state;
+  const { gridSnap, gridCellSize } = opts;
+
+  return {
+    ...board,
+    spots: board.spots.map((spot) => {
+      const p = positions.get(spot.id)!;
+      let x = Math.round(p.x);
+      let y = Math.round(p.y);
+      if (gridSnap && !fixed.has(spot.id)) {
+        x = snapToGrid(x, gridCellSize);
+        y = snapToGrid(y, gridCellSize);
+      }
+      return { ...spot, x, y };
+    }),
+  };
+}
+
+/**
+ * Instant full-pipeline beautify.
+ *
+ * Runs all iterations synchronously and returns a new Board.
+ * Use `initBeautify` + `runFRStep` + `coolTemperature` for the animated path.
+ */
+export function beautifyBoard(board: Board, options?: BeautifyOptions): Board {
+  if (board.spots.length === 0) return board;
+
+  const state = initBeautify(board, options);
+  const { iterations } = state.opts;
+
+  for (let iter = 0; iter < iterations; iter++) {
+    runFRStep(board.spots, board.passages, state);
+    coolTemperature(state, iter);
+  }
+
+  return applyPositions(board, state);
+}


### PR DESCRIPTION
Implements a Fruchterman-Reingold layout algorithm for the board editor
that improves spot placement without changing the board topology.

- `beautify.utils.ts`: pure FR algorithm with `initBeautify`, `runFRStep`,
  `coolTemperature`, `applyPositions`, and `beautifyBoard` (instant pipeline)
- Phase 0 pre-positions each player's entry spots to their bench edge,
  distributed evenly across the board width, before running F-R
- Flag spots are pinned in place; only normal spots float freely
- `board.store.ts`: adds `beautify()`, `stopBeautify()`, and
  `toggleBeautifyAnimation()` methods plus `isBeautifying` / `beautifyAnimated`
  state; animated path drives rAF frame-by-frame updates for live morphing
- Board controls UI: ✦ Beautify button, ■ Stop button (while running),
  and Animate ON/OFF toggle
- 19 unit tests covering topology preservation, boundary clamping,
  entry-spot pre-positioning, fixed-spot pinning, grid snap, and cooling

https://claude.ai/code/session_0191h28RxomxReLkjK4phjiW